### PR TITLE
Update Interrupt to ReactionBefore plus Lay On Hands

### DIFF
--- a/server/game/AtomicEvent.js
+++ b/server/game/AtomicEvent.js
@@ -24,10 +24,6 @@ class AtomicEvent {
         }
     }
 
-    allowAutomaticSave() {
-        return false;
-    }
-
     cancel() {
         this.cancelled = true;
 

--- a/server/game/EventTrackers/EventPlayedTracker.js
+++ b/server/game/EventTrackers/EventPlayedTracker.js
@@ -5,11 +5,7 @@ class EventPlayedTracker {
 
     constructor(game, endingEvent) {
         this.events = [];
-        // TODO: should be onCardPlayed but it is currently fired after the
-        // ability has resolved. That would be too late in case of chains of
-        // interrupt cards, e.g. Hand's Judgment vs Hand's Judgment vs Hand's
-        // Judgment
-        game.on('onCardAbilityInitiated:cancelinterrupt', event => this.trackEvent(event));
+        game.on('onCardAbilityInitiated:cancelreaction', event => this.trackEvent(event));
         game.on(endingEvent, () => this.clearEvents());
     }
 

--- a/server/game/GameActions/SendHome.js
+++ b/server/game/GameActions/SendHome.js
@@ -18,9 +18,6 @@ class SendHome extends GameAction {
     createEvent({ card, options = {}, context }) {
         let params = this.getDefaultOptions(options);
         return this.event('onDudeSentHome', { card, options: params, context }, event => {
-            if(options.fromPosse && event.card.game.shootout) {
-                event.card.game.shootout.removeFromPosse(card);
-            } 
             event.card.sendHome(event.options, context);
         });
     }

--- a/server/game/GroupedCardEvent.js
+++ b/server/game/GroupedCardEvent.js
@@ -1,10 +1,6 @@
 const Event = require('./event.js');
 
 class GroupedCardEvent extends Event {
-    allowAutomaticSave() {
-        return false;
-    }
-
     saveCard(card) {
         this.removeCard(card);
         card.markAsSaved();

--- a/server/game/NullEvent.js
+++ b/server/game/NullEvent.js
@@ -14,10 +14,6 @@ class NullEvent {
     emitTo() {
     }
 
-    allowAutomaticSave() {
-        return false;
-    }
-
     cancel() {
         this.cancelled = true;
     }

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -10,7 +10,7 @@ const BaseCardSelector = require('./CardSelectors/BaseCardSelector');
 
 /**
  * Base class representing an ability that can be done by the player. This
- * includes card actions, reactions, interrupts, playing a card.
+ * includes card actions, reactions, playing a card.
  *
  * Most of the methods take a context object. While the structure will vary from
  * inheriting classes, it is guaranteed to have at least the `game` object, the

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -3,9 +3,8 @@ const _ = require('underscore');
 
 const AbilityDsl = require('./abilitydsl');
 const CardAction = require('./cardaction');
-const CardForcedInterrupt = require('./cardforcedinterrupt');
 const CardTraitReaction = require('./cardtraitreaction');
-const CardInterrupt = require('./cardinterrupt');
+const CardInsteadReaction = require('./cardinsteadreaction');
 const CardMatcher = require('./CardMatcher');
 const CardReaction = require('./cardreaction');
 const CustomPlayAction = require('./PlayActions/CustomPlayAction');
@@ -17,6 +16,8 @@ const JobAction = require('./jobaction');
 const NullCard = require('./nullcard');
 const SpellAction = require('./spellaction');
 const SpellReaction = require('./spellreaction');
+const SpellInsteadReaction = require('./spellinsteadreaction');
+const CardTraitInsteadReaction = require('./cardtraitinsteadreaction');
 
 class BaseCard {
     constructor(owner, cardData) {
@@ -163,27 +164,32 @@ class BaseCard {
     // 4) Other reacts
     //
     reaction(properties) {
-        var reaction = new CardReaction(this.game, this, properties);
+        var reaction;
+        if(properties.usesInstead || properties.canCancel) {
+            reaction = new CardInsteadReaction(this.game, this, properties);            
+        } else {
+            reaction = new CardReaction(this.game, this, properties);
+        }
         this.abilities.reactions.push(reaction);
     }
 
     spellReaction(properties) {
-        var reaction = new SpellReaction(this.game, this, properties);
+        var reaction;
+        if(properties.usesInstead || properties.canCancel) {
+            reaction = new SpellInsteadReaction(this.game, this, properties);            
+        } else {
+            reaction = new SpellReaction(this.game, this, properties);
+        }
         this.abilities.reactions.push(reaction);
     }
 
     traitReaction(properties) {
-        var reaction = new CardTraitReaction(this.game, this, properties);
-        this.abilities.reactions.push(reaction);
-    }
-
-    interrupt(properties) {
-        var reaction = new CardInterrupt(this.game, this, properties);
-        this.abilities.reactions.push(reaction);
-    }
-
-    forcedInterrupt(properties) {
-        var reaction = new CardForcedInterrupt(this.game, this, properties);
+        var reaction;
+        if(properties.usesInstead) {
+            reaction = new CardTraitInsteadReaction(this.game, this, properties);            
+        } else {
+            reaction = new CardTraitReaction(this.game, this, properties);
+        }
         this.abilities.reactions.push(reaction);
     }
 

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -810,6 +810,14 @@ class BaseCard {
         return this.game.findLocation(this.gamelocation);
     }
 
+    isAdjacent(locationUuid) {
+        if(this.location !== 'play area') {
+            return false;
+        }
+        let gameLocationObject = this.getGameLocation();
+        return gameLocationObject && gameLocationObject.isAdjacent(locationUuid);
+    }
+
     isInControlledLocation() {
         return this.locationCard && this.locationCard.controller === this.controller;
     }

--- a/server/game/cardforcedinterrupt.js
+++ b/server/game/cardforcedinterrupt.js
@@ -1,9 +1,0 @@
-const TraitTriggeredAbility = require('./traittriggeredability.js');
-
-class CardForcedInterrupt extends TraitTriggeredAbility {
-    constructor(game, card, properties) {
-        super(game, card, 'forcedinterrupt', properties);
-    }
-}
-
-module.exports = CardForcedInterrupt;

--- a/server/game/cardinsteadreaction.js
+++ b/server/game/cardinsteadreaction.js
@@ -1,0 +1,9 @@
+const PromptedTriggeredAbility = require('./promptedtriggeredability.js');
+
+class CardInsteadReaction extends PromptedTriggeredAbility {
+    constructor(game, card, properties) {
+        super(game, card, properties.canCancel ? 'cancelreaction' : 'insteadreaction', properties);
+    }
+}
+
+module.exports = CardInsteadReaction;

--- a/server/game/cardinterrupt.js
+++ b/server/game/cardinterrupt.js
@@ -1,9 +1,0 @@
-const PromptedTriggeredAbility = require('./promptedtriggeredability.js');
-
-class CardInterrupt extends PromptedTriggeredAbility {
-    constructor(game, card, properties) {
-        super(game, card, properties.canCancel ? 'cancelinterrupt' : 'interrupt', properties);
-    }
-}
-
-module.exports = CardInterrupt;

--- a/server/game/cardreaction.js
+++ b/server/game/cardreaction.js
@@ -29,10 +29,10 @@ const PromptedTriggeredAbility = require('./promptedtriggeredability.js');
  *            be in in order to activate the reaction. Defaults to 'play area'.
  * player   - optional function that returns which player to prompt for the
  *            ability. By default, the player that controls the card will be
- *            prompted. Used for reactions / interrupts that any player can
+ *            prompted. Used for reactions that any player can
  *            trigger.
  * cannotBeCanceled - optional boolean that determines whether an ability can
- *                    be canceled using a cancel interrupt.
+ *                    be canceled using a cancel reaction.
  */
 class CardReaction extends PromptedTriggeredAbility {
     constructor(game, card, properties) {

--- a/server/game/cards/01-DTR/BloodCurse.js
+++ b/server/game/cards/01-DTR/BloodCurse.js
@@ -13,7 +13,7 @@ class BloodCurse extends SpellCard {
                     controller: 'any', 
                     condition: card => 
                         card.gamelocation === this.gamelocation ||
-                        card.getGameLocation().isAdjacent(this.gamelocation)
+                        card.isAdjacent(this.gamelocation)
                 },
                 cardType: ['dude']
             },

--- a/server/game/cards/01-DTR/MicahRyse.js
+++ b/server/game/cards/01-DTR/MicahRyse.js
@@ -15,7 +15,7 @@ class MicahRyse extends DudeCard {
                 this.game.promptForLocation(context.player, {
                     activePromptTitle: 'Select where Mycah should move to',
                     waitingPromptTitle: 'Waiting for opponent to select location for Mycah',
-                    cardCondition: { location: 'play area', condition: card => card.getGameLocation().isAdjacent(this.gamelocation)},
+                    cardCondition: { location: 'play area', condition: card => card.isAdjacent(this.gamelocation)},
                     onSelect: (player, location) => {
                         this.game.resolveGameAction(GameActions.moveDude({ 
                             card: this, 

--- a/server/game/cards/01-DTR/PistolWhip.js
+++ b/server/game/cards/01-DTR/PistolWhip.js
@@ -16,7 +16,7 @@ class PistolWhip extends ActionCard {
                 gameAction: ['sendHome']
             },
             message: context =>
-                this.game.addMessage('{0} uses {1} to send {2} home booted', context.player, this),
+                this.game.addMessage('{0} uses {1} to send {2} home booted', context.player, this, context.target),
             handler: context => {
                 this.applyAbilityEffect(context.ability, ability => ({
                     match: context.costs.boot,

--- a/server/game/cards/01-DTR/RunEmDown.js
+++ b/server/game/cards/01-DTR/RunEmDown.js
@@ -25,7 +25,7 @@ class RunEmDown extends ActionCard {
                         this.game.promptForSelect(player, {
                             activePromptTitle: 'Select a dude to be runned down',
                             waitingPromptTitle: 'Waiting for opponent to select dude',
-                            cardCondition: card => card.location === 'play area' && card.getGameLocation().isAdjacent(context.target.uuid) && !card.hasHorse(),
+                            cardCondition: card => card.location === 'play area' && card.isAdjacent(context.target.uuid) && !card.hasHorse(),
                             cardType: 'dude',
                             onSelect: (player, runnedDude) => {
                                 let action = GameActions.simultaneously(

--- a/server/game/cards/03-FF/LayOnHands.js
+++ b/server/game/cards/03-FF/LayOnHands.js
@@ -7,11 +7,13 @@ class LayOnHands extends SpellCard {
             usesInstead: true,
             when: {
                 onCardAced: event => event.card.getType() === 'dude' && 
+                    event.originalLocation === 'play area' &&
                     (event.card.gamelocation === this.gamelocation ||
-                    event.card.getGameLocation().isAdjacent(this.gamelocation)),
+                    event.card.isAdjacent(this.gamelocation)),
                 onCardDiscarded: event => event.card.getType() === 'dude' && 
+                    event.originalLocation === 'play area' &&
                     (event.card.gamelocation === this.gamelocation ||
-                    event.card.getGameLocation().isAdjacent(this.gamelocation)) &&
+                    event.card.isAdjacent(this.gamelocation)) &&
                     event.isCasualty
             },
             cost: ability.costs.bootSelf(),
@@ -24,7 +26,7 @@ class LayOnHands extends SpellCard {
                             match: context.event.card,
                             effect: ability.effects.doesNotUnbootAtSundown()
                         }));
-                        this.game.addMessage('{0} uses {1} to save {2} and send them home instead', context.player, this, context.event.card);
+                        this.game.addMessage('{0} uses {1} to save {2} and send them home booted instead', context.player, this, context.event.card);
                     });
                 });
             }

--- a/server/game/cards/03-FF/LayOnHands.js
+++ b/server/game/cards/03-FF/LayOnHands.js
@@ -1,0 +1,37 @@
+const GameActions = require('../../GameActions/index.js');
+const SpellCard = require('../../spellcard.js');
+
+class LayOnHands extends SpellCard {
+    setupCardAbilities(ability) {
+        this.spellReaction({
+            usesInstead: true,
+            when: {
+                onCardAced: event => event.card.getType() === 'dude' && 
+                    (event.card.gamelocation === this.gamelocation ||
+                    event.card.getGameLocation().isAdjacent(this.gamelocation)),
+                onCardDiscarded: event => event.card.getType() === 'dude' && 
+                    (event.card.gamelocation === this.gamelocation ||
+                    event.card.getGameLocation().isAdjacent(this.gamelocation)) &&
+                    event.isCasualty
+            },
+            cost: ability.costs.bootSelf(),
+            difficulty: 8,
+            onSuccess: context => {
+                this.game.resolveGameAction(GameActions.bootCard({ card: this.parent, allowSave: false }), context).thenExecute(() => {
+                    context.replaceHandler(() => {
+                        this.game.resolveGameAction(GameActions.sendHome({ card: context.event.card }), context);
+                        this.untilEndOfRound(ability => ({
+                            match: context.event.card,
+                            effect: ability.effects.doesNotUnbootAtSundown()
+                        }));
+                        this.game.addMessage('{0} uses {1} to save {2} and send them home instead', context.player, this, context.event.card);
+                    });
+                });
+            }
+        });
+    }
+}
+
+LayOnHands.code = '05029';
+
+module.exports = LayOnHands;

--- a/server/game/cards/03-FF/Phantasm.js
+++ b/server/game/cards/03-FF/Phantasm.js
@@ -14,7 +14,7 @@ class Phantasm extends SpellCard {
                     controller: 'opponent', 
                     condition: card => 
                         (card.gamelocation === this.gamelocation ||
-                        card.getGameLocation().isAdjacent(this.gamelocation)) &&
+                        card.isAdjacent(this.gamelocation)) &&
                         !card.booted
                 },
                 cardType: ['dude'],
@@ -29,7 +29,7 @@ class Phantasm extends SpellCard {
                     cardCondition: {
                         location: 'play area',
                         condition: card => 
-                            card.getGameLocation().isAdjacent(context.target.gamelocation)
+                            card.isAdjacent(context.target.gamelocation)
                     },
                     cardType: ['location', 'townsquare'],
                     onSelect: (player, location) => {
@@ -70,7 +70,7 @@ class Phantasm extends SpellCard {
                     cardCondition: {
                         location: 'play area',
                         condition: card => 
-                            card.getGameLocation().isAdjacent(context.target.gamelocation)
+                            card.isAdjacent(context.target.gamelocation)
                     },
                     cardType: ['location', 'townsquare'],
                     onSelect: (player, location) => {

--- a/server/game/cards/04.1-FJ/Confession.js
+++ b/server/game/cards/04.1-FJ/Confession.js
@@ -16,7 +16,7 @@ class Confession extends SpellCard {
                     location: 'play area', 
                     condition: card =>
                         card.gamelocation === this.gamelocation || 
-                        card.getGameLocation().isAdjacent(this.gamelocation)
+                        card.isAdjacent(this.gamelocation)
                 },
                 cardType: ['dude'],
                 gameAction: 'addBounty'
@@ -45,7 +45,7 @@ class Confession extends SpellCard {
                     location: 'play area', 
                     condition: card =>
                         (card.gamelocation === this.gamelocation || 
-                        card.getGameLocation().isAdjacent(this.gamelocation)) &&
+                        card.isAdjacent(this.gamelocation)) &&
                         card.isWanted()
                 },
                 cardType: ['dude'],

--- a/server/game/cardtraitinsteadreaction.js
+++ b/server/game/cardtraitinsteadreaction.js
@@ -1,0 +1,9 @@
+const TraitTriggeredAbility = require('./traittriggeredability.js');
+
+class CardTraitInsteadReaction extends TraitTriggeredAbility {
+    constructor(game, card, properties) {
+        super(game, card, 'traitinsteadreaction', properties);
+    }
+}
+
+module.exports = CardTraitInsteadReaction;

--- a/server/game/dudecard.js
+++ b/server/game/dudecard.js
@@ -183,7 +183,13 @@ class DudeCard extends DrawCard {
     }
 
     sendHome(options = {}, context) {
-        this.game.resolveGameAction(GameActions.moveDude({ card: this, targetUuid: this.owner.outfit.uuid, options }), context);
+        if(options.needToBoot) {
+            this.game.resolveGameAction(GameActions.bootCard({ card: this }), context);
+        }
+        this.game.resolveGameAction(GameActions.moveDude({ card: this, targetUuid: this.controller.outfit.uuid, options }), context);
+        if(options.fromPosse && this.game.shootout) {
+            this.game.shootout.removeFromPosse(this);
+        } 
     }
 
     moveToLocation(destinationUuid) {
@@ -342,7 +348,7 @@ class DudeCard extends DrawCard {
         if(!shootout) {
             return { canJoin: false };
         } 
-        if(this.getGameLocation().isAdjacent(shootout.gamelocation) && (!this.booted || allowBooted)) {
+        if(this.isAdjacent(shootout.gamelocation) && (!this.booted || allowBooted)) {
             return { canJoin: true, needToBoot: true };
         }
 
@@ -350,7 +356,7 @@ class DudeCard extends DrawCard {
             if(this.gamelocation === shootout.leader.gamelocation) {
                 return { canJoin: true, needToBoot: true };
             } 
-            if(this.getGameLocation().isAdjacent(shootout.leader.gamelocation)) {
+            if(this.isAdjacent(shootout.leader.gamelocation)) {
                 return { canJoin: true, needToBoot: true };
             }         
         }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -279,6 +279,7 @@ const Effects = {
         };
     },
     doesNotGetBountyOnJoin: optionEffect('doesNotGetBountyOnJoin'),
+    doesNotUnbootAtSundown: optionEffect('doesNotUnbootAtSundown'),
     restrictAttachmentsTo: function(trait) {
         return Effects.addKeyword(`No attachments except <i>${trait}</i>`);
     },

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -49,10 +49,6 @@ class Event {
         }
     }
 
-    allowAutomaticSave() {
-        return this.allowSave && this.automaticSaveWithDupe && !!this.card;
-    }
-
     saveCard() {
         if(!this.card || this.cancelled) {
             return;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -852,7 +852,7 @@ class Game extends EventEmitter {
             if(context.ability && context.ability.title !== 'Trade') {
                 this.currentPlayWindow.markActionAsTaken(context.player);
             }
-        } else if(this.currentPhase !== 'setup' || this.hasOpenReactionBeforeWindow()) {
+        } else if(this.currentPhase !== 'setup' || this.hasOpenReactionWindow()) {
             this.addAlert('danger', '{0} uses {1} outside of a play window', context.player, context.source);
         }
     }
@@ -931,7 +931,7 @@ class Game extends EventEmitter {
         }
     }
 
-    hasOpenReactionBeforeWindow() {
+    hasOpenReactionWindow() {
         return this.abilityWindowStack.length !== 0;
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -21,7 +21,7 @@ const EventWindow = require('./gamesteps/eventwindow.js');
 const AbilityResolver = require('./gamesteps/abilityresolver.js');
 const TraitTriggeredAbilityWindow = require('./gamesteps/TraitTriggeredAbilityWindow.js');
 const TriggeredAbilityWindow = require('./gamesteps/TriggeredAbilityWindow.js');
-const InterruptWindow = require('./gamesteps/InterruptWindow');
+const ReactionBeforeWindow = require('./gamesteps/ReactionBeforeWindow');
 const Event = require('./event.js');
 const NullEvent = require('./NullEvent');
 const AtomicEvent = require('./AtomicEvent.js');
@@ -852,7 +852,7 @@ class Game extends EventEmitter {
             if(context.ability && context.ability.title !== 'Trade') {
                 this.currentPlayWindow.markActionAsTaken(context.player);
             }
-        } else if(this.currentPhase !== 'setup' || this.hasOpenInterruptOrReactionWindow()) {
+        } else if(this.currentPhase !== 'setup' || this.hasOpenReactionBeforeWindow()) {
             this.addAlert('danger', '{0} uses {1} outside of a play window', context.player, context.source);
         }
     }
@@ -895,7 +895,7 @@ class Game extends EventEmitter {
         this.queueSimpleStep(() => this.abilityWindowStack.pop());
     }
 
-    openInterruptWindowForAttachedEvents(event) {
+    openReactionBeforeWindowForAttachedEvents(event) {
         let attachedEvents = [];
         for(let concurrentEvent of event.getConcurrentEvents()) {
             attachedEvents = attachedEvents.concat(concurrentEvent.attachedEvents);
@@ -911,7 +911,7 @@ class Game extends EventEmitter {
             groupedEvent.addChildEvent(attachedEvent);
         }
 
-        this.queueStep(new InterruptWindow(this, groupedEvent, () => this.postEventCalculations()));
+        this.queueStep(new ReactionBeforeWindow(this, groupedEvent, () => this.postEventCalculations()));
     }
 
     registerAbility(ability, event) {
@@ -931,7 +931,7 @@ class Game extends EventEmitter {
         }
     }
 
-    hasOpenInterruptOrReactionWindow() {
+    hasOpenReactionBeforeWindow() {
         return this.abilityWindowStack.length !== 0;
     }
 

--- a/server/game/gamesteps/BaseAbilityWindow.js
+++ b/server/game/gamesteps/BaseAbilityWindow.js
@@ -100,7 +100,7 @@ class BaseAbilityWindow extends BaseStep {
             return;
         }
 
-        this.game.openInterruptWindowForAttachedEvents(this.event);
+        this.game.openReactionBeforeWindowForAttachedEvents(this.event);
     }
 }
 

--- a/server/game/gamesteps/CancelTimer.js
+++ b/server/game/gamesteps/CancelTimer.js
@@ -1,6 +1,5 @@
 const cancellableEvents = {
-    onCardAbilityInitiated: 'cancelinterrupt',
-    onClaimApplied: 'interrupt'
+    onCardAbilityInitiated: 'cancelreaction'
 };
 
 class CancelTimer {

--- a/server/game/gamesteps/ReactionBeforeWindow.js
+++ b/server/game/gamesteps/ReactionBeforeWindow.js
@@ -2,7 +2,7 @@ const BaseStep = require('./basestep.js');
 const GamePipeline = require('../gamepipeline.js');
 const SimpleStep = require('./simplestep.js');
 
-class InterruptWindow extends BaseStep {
+class ReactionBeforeWindow extends BaseStep {
     constructor(game, event, postHandlerFunc = () => true) {
         super(game);
 
@@ -10,10 +10,9 @@ class InterruptWindow extends BaseStep {
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SimpleStep(game, () => this.executeBeforeHandlers()),
-            new SimpleStep(game, () => this.openAbilityWindow('cancelinterrupt')),
-            new SimpleStep(game, () => this.automaticSave()),
-            new SimpleStep(game, () => this.openAbilityWindow('forcedinterrupt')),
-            new SimpleStep(game, () => this.openAbilityWindow('interrupt')),
+            new SimpleStep(game, () => this.openAbilityWindow('cancelreaction')),
+            new SimpleStep(game, () => this.openAbilityWindow('traitinsteadreaction')),
+            new SimpleStep(game, () => this.openAbilityWindow('insteadreaction')),
             new SimpleStep(game, () => this.executeHandler()),
             new SimpleStep(game, () => this.openWindowForAttachedEvents()),
             new SimpleStep(game, () => this.executePostHandler())
@@ -45,20 +44,6 @@ class InterruptWindow extends BaseStep {
         return this.pipeline.continue();
     }
 
-    automaticSave() {
-        if(this.event.cancelled) {
-            return;
-        }
-
-        /* TODO M2 here add saves if any
-        for(let event of this.event.getConcurrentEvents()) {
-            if(event.allowAutomaticSave()) {
-                event.cancel();
-            }
-        }
-        */
-    }
-
     openAbilityWindow(abilityType) {
         if(this.event.cancelled) {
             return;
@@ -83,7 +68,7 @@ class InterruptWindow extends BaseStep {
             return;
         }
 
-        this.game.openInterruptWindowForAttachedEvents(this.event);
+        this.game.openReactionBeforeWindowForAttachedEvents(this.event);
     }
 
     executePostHandler() {
@@ -111,4 +96,4 @@ class InterruptWindow extends BaseStep {
     }
 }
 
-module.exports = InterruptWindow;
+module.exports = ReactionBeforeWindow;

--- a/server/game/gamesteps/TriggeredAbilityWindowTitles.js
+++ b/server/game/gamesteps/TriggeredAbilityWindowTitles.js
@@ -10,7 +10,8 @@ const EventToTitleFunc = {
 
 const AbilityTypeToWord = {
     reaction: 'reaction',
-    traitreaction: 'trait reaction'
+    traitreaction: 'trait reaction',
+    insteadreaction: 'reaction'
 };
 
 const AbilityWindowTitles = {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -201,9 +201,9 @@ class AbilityResolver extends BaseStep {
 
     raiseOnAbilityResolvedEvent() {
         // An event card is considered to be played even if it has been
-        // cancelled. Raising the event here will allow forced reactions and
+        // cancelled. Raising the event here will allow trait reactions and
         // reactions to fire with the appropriate timing. There are no cards
-        // with an interrupt to a card being played. If any are ever released,
+        // with a reaction to a card being played. If any are ever released,
         // then this event will need to wrap the execution of the entire
         // ability instead.
         if(this.ability.isPlayableActionAbility()) {

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -1,7 +1,7 @@
 const BaseStep = require('./basestep.js');
 const GamePipeline = require('../gamepipeline.js');
 const SimpleStep = require('./simplestep.js');
-const InterruptWindow = require('./InterruptWindow');
+const ReactionBeforeWindow = require('./ReactionBeforeWindow');
 
 class EventWindow extends BaseStep {
     constructor(game, event, postHandlerFunc = () => true) {
@@ -10,7 +10,7 @@ class EventWindow extends BaseStep {
         this.event = event;
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
-            new InterruptWindow(game, event, postHandlerFunc),
+            new ReactionBeforeWindow(game, event, postHandlerFunc),
             new SimpleStep(game, () => this.emitBaseEvent()),
             new SimpleStep(game, () => this.openAbilityWindow('traitreaction')),
             new SimpleStep(game, () => this.openAbilityWindow('reaction')),

--- a/server/game/gamesteps/sundownphase.js
+++ b/server/game/gamesteps/sundownphase.js
@@ -1,4 +1,3 @@
-const _ = require('underscore');
 const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
 const DiscardPrompt = require('./sundown/discardprompt.js');
@@ -18,17 +17,16 @@ class SundownPhase extends Phase {
     }
 
     sundownRedraw() {
-        _.each(this.game.getPlayers(), player => {
+        this.game.getPlayers().forEach(player => {
             player.sundownRedraw();
         });
     }
 
     checkWinCondition() {
         let potentialWinner = [];
-        _.each(this.game.getPlayers(), player => {
-            let opponents = _.reject(this.game.getPlayers(), activePlayer => activePlayer === player);
-            if(opponents.length > 0 && _.every(opponents, opponent => opponent.getTotalInfluence() < player.getTotalControl())) {
-                //console.log("player control points" + player.getTotalControl());
+        this.game.getPlayers().forEach(player => {
+            let opponents = this.game.getPlayers().filter(activePlayer => activePlayer !== player);
+            if(opponents.length > 0 && opponents.every(opponent => opponent.getTotalInfluence() < player.getTotalControl())) {
                 potentialWinner.push(player);
             }
         });
@@ -40,9 +38,11 @@ class SundownPhase extends Phase {
     }
 
     unbootCards() { 
-        _.each(this.game.getPlayers(), player => {
-            _.each(player.cardsInPlay, card => {
-                player.unbootCard(card);
+        this.game.getPlayers().forEach(player => {
+            player.cardsInPlay.forEach(card => {
+                if(!card.options.contains('doesNotUnbootAtSundown')) {
+                    player.unbootCard(card);
+                }
             });
         });
     }

--- a/server/game/locationcard.js
+++ b/server/game/locationcard.js
@@ -65,9 +65,9 @@ class LocationCard extends DrawCard {
         if(!this.gameLocationObject) {
             return [];
         }
-        let adjacentLocations = this.game.filterCardsInPlay(card => card.isLocationCard() && this.getGameLocation().isAdjacent(card.uuid)).
+        let adjacentLocations = this.game.filterCardsInPlay(card => card.isLocationCard() && this.isAdjacent(card.uuid)).
             map(card => card.getGameLocation());
-        if(this.getGameLocation().isAdjacent(this.game.townsquare.uuid)) {
+        if(this.isAdjacent(this.game.townsquare.uuid)) {
             adjacentLocations.concat(this.game.townsquare);
         }
         return adjacentLocations;

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -27,10 +27,10 @@ const TriggeredAbility = require('./triggeredability.js');
  *            be in in order to activate the reaction. Defaults to 'play area'.
  * player   - optional function that returns which player to prompt for the
  *            ability. By default, the player that controls the card will be
- *            prompted. Used for reactions / interrupts that any player can
+ *            prompted. Used for reactions that any player can
  *            trigger.
  * cannotBeCanceled - optional boolean that determines whether an ability can
- *                    be canceled using a cancel interrupt.
+ *                    be canceled using a cancel reaction.
  */
 class PromptedTriggeredAbility extends TriggeredAbility {
     constructor(game, card, type, properties) {

--- a/server/game/spellinsteadreaction.js
+++ b/server/game/spellinsteadreaction.js
@@ -1,0 +1,22 @@
+const PromptedTriggeredAbility = require('./promptedtriggeredability.js');
+const Spell = require('./spell.js');
+
+class SpellInsteadReaction extends PromptedTriggeredAbility {
+    constructor(game, card, properties) {
+        super(game, card, properties.canCancel ? 'cancelreaction' : 'insteadreaction', properties);
+        this.spell = new Spell(this, properties);
+    }
+
+    meetsRequirements(context) {
+        if(super.meetsRequirements(context)) {
+            return this.spell.canBeCasted(context.player);
+        }
+        return false;
+    }
+
+    executeHandler(context) {
+        this.spell.executeSpell(context, () => super.executeHandler(context));
+    }
+}
+
+module.exports = SpellInsteadReaction;

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -65,7 +65,7 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
-        if(event.ability && !!event.ability.cannotBeCanceled && this.eventType === 'cancelinterrupt') {
+        if(event.ability && !!event.ability.cannotBeCanceled && this.eventType === 'cancelreaction') {
             return;
         }
 
@@ -114,7 +114,7 @@ class TriggeredAbility extends BaseAbility {
     }
 
     isEventListeningLocation(location) {
-        // Reactions / interrupts for playable event cards need to listen for
+        // Reactions for playable event cards need to listen for
         // game events in all open information locations plus while in hand.
         // The location property of the ability will prevent it from firing in
         // inappropriate locations when requirements are checked for the ability.

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -1,5 +1,6 @@
 const BaseAbility = require('./baseability.js');
 const Costs = require('./costs.js');
+const HandlerGameActionWrapper = require('./GameActions/HandlerGameActionWrapper.js');
 const TriggeredAbilityContext = require('./TriggeredAbilityContext.js');
 
 class TriggeredAbility extends BaseAbility {
@@ -15,6 +16,14 @@ class TriggeredAbility extends BaseAbility {
 
         if(card.getType() === 'action' && !properties.ignoreEventCosts) {
             this.cost = this.cost.concat(Costs.playAction());
+        }
+
+        if(!this.gameAction) {
+            if(card.getType() !== 'spell') {
+                throw new Error('Reactions must have a `gameAction` or `handler` property.');
+            } else {
+                this.gameAction = new HandlerGameActionWrapper({ handler: () => true });
+            }
         }
     }
 

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -108,7 +108,7 @@ var customMatchers = {
                 }
 
                 let selectableCardNames = actual.player.getSelectableCards().map(card => card.title);
-                let isPromptingAbility = actual.game.hasOpenReactionBeforeWindow();
+                let isPromptingAbility = actual.game.hasOpenReactionWindow();
                 let includesCard = selectableCardNames.some(cardName => util.equals(cardName, expected, customEqualityMatchers));
 
                 result.pass = isPromptingAbility && includesCard;

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -108,7 +108,7 @@ var customMatchers = {
                 }
 
                 let selectableCardNames = actual.player.getSelectableCards().map(card => card.title);
-                let isPromptingAbility = actual.game.hasOpenInterruptOrReactionWindow();
+                let isPromptingAbility = actual.game.hasOpenReactionBeforeWindow();
                 let includesCard = selectableCardNames.some(cardName => util.equals(cardName, expected, customEqualityMatchers));
 
                 result.pass = isPromptingAbility && includesCard;

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -155,7 +155,7 @@ class PlayerInteractionWrapper {
     }
 
     triggerAbility(cardOrCardName) {
-        if(!this.game.hasOpenInterruptOrReactionWindow()) {
+        if(!this.game.hasOpenReactionBeforeWindow()) {
             throw new Error(`Couldn't trigger ability for ${this.name}. Not in an ability window. Current prompt is:\n${this.formatPrompt()}`);
         }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -155,7 +155,7 @@ class PlayerInteractionWrapper {
     }
 
     triggerAbility(cardOrCardName) {
-        if(!this.game.hasOpenReactionBeforeWindow()) {
+        if(!this.game.hasOpenReactionWindow()) {
             throw new Error(`Couldn't trigger ability for ${this.name}. Not in an ability window. Current prompt is:\n${this.formatPrompt()}`);
         }
 

--- a/test/server/game/openInterruptWindowForAttachedEvents.spec.js
+++ b/test/server/game/openInterruptWindowForAttachedEvents.spec.js
@@ -15,10 +15,10 @@ describe('Game', function() {
         describe('when the event has no attached events', function() {
             beforeEach(function() {
                 this.eventSpy.attachedEvents = [];
-                this.game.openInterruptWindowForAttachedEvents(this.eventSpy);
+                this.game.openReactionBeforeWindowForAttachedEvents(this.eventSpy);
             });
 
-            it('should not open an interrupt window', function() {
+            it('should not open a reaction (before) window', function() {
                 expect(this.game.queueStep).not.toHaveBeenCalled();
             });
         });
@@ -28,16 +28,16 @@ describe('Game', function() {
                 this.attachedEvent1 = { event: 1 };
                 this.attachedEvent2 = { event: 1 };
                 this.eventSpy.attachedEvents = [this.attachedEvent1, this.attachedEvent2];
-                this.game.openInterruptWindowForAttachedEvents(this.eventSpy);
+                this.game.openReactionBeforeWindowForAttachedEvents(this.eventSpy);
             });
 
             it('should clear the attached events from the initial event', function() {
                 expect(this.eventSpy.clearAttachedEvents).toHaveBeenCalled();
             });
 
-            it('should open an interrupt window', function() {
-                const InterruptWindow = require('../../../server/game/gamesteps/InterruptWindow');
-                expect(this.game.queueStep).toHaveBeenCalledWith(jasmine.any(InterruptWindow));
+            it('should open an reaction(before) window', function() {
+                const ReactionBeforeWindow = require('../../../server/game/gamesteps/ReactionBeforeWindow');
+                expect(this.game.queueStep).toHaveBeenCalledWith(jasmine.any(ReactionBeforeWindow));
             });
 
             it('should create an event grouping the attached events', function() {

--- a/test/server/gamesteps/BaseAbilityWindow.spec.js
+++ b/test/server/gamesteps/BaseAbilityWindow.spec.js
@@ -11,7 +11,7 @@ describe('BaseAbilityWindow', function() {
 
         this.window = new BaseAbilityWindow(this.gameSpy, {
             event: this.eventSpy,
-            abilityType: 'interrupt'
+            abilityType: 'insteadreaction'
         });
     });
 
@@ -29,7 +29,7 @@ describe('BaseAbilityWindow', function() {
         it('should emit the associated event to trigger associated abilities', function() {
             this.window.gatherChoices();
 
-            expect(this.eventSpy.emitTo).toHaveBeenCalledWith(this.gameSpy, 'interrupt');
+            expect(this.eventSpy.emitTo).toHaveBeenCalledWith(this.gameSpy, 'insteadreaction');
         });
     });
 

--- a/test/server/gamesteps/TraitTriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TraitTriggeredAbilityWindow.spec.js
@@ -17,7 +17,7 @@ describe('TraitTriggeredAbilityWindow', function() {
 
         this.window = new TraitTriggeredAbilityWindow(this.gameSpy, {
             event: this.eventSpy,
-            abilityType: 'forcedinterrupt'
+            abilityType: 'traitinsteadreaction'
         });
 
         function createCard(properties) {

--- a/test/server/gamesteps/TriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TriggeredAbilityWindow.spec.js
@@ -18,7 +18,7 @@ describe('TriggeredAbilityWindow', function() {
 
         this.window = new TriggeredAbilityWindow(this.gameSpy, {
             event: this.eventSpy,
-            abilityType: 'interrupt'
+            abilityType: 'insteadreaction'
         });
 
         spyOn(this.window, 'gatherChoices');

--- a/test/server/gamesteps/eventwindow.spec.js
+++ b/test/server/gamesteps/eventwindow.spec.js
@@ -2,9 +2,9 @@ const EventWindow = require('../../../server/game/gamesteps/eventwindow.js');
 
 describe('EventWindow', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['openAbilityWindow', 'openInterruptWindowForAttachedEvents', 'saveWithDupe']);
+        this.gameSpy = jasmine.createSpyObj('game', ['openAbilityWindow', 'openReactionBeforeWindowForAttachedEvents', 'saveWithDupe']);
         this.gameSpy.beforeEventHandlers = {};
-        this.eventSpy = jasmine.createSpyObj('event', ['allowAutomaticSave', 'cancel', 'clearAttachedEvents', 'emitTo', 'executeHandler', 'executePostHandler', 'getConcurrentEvents']);
+        this.eventSpy = jasmine.createSpyObj('event', ['cancel', 'clearAttachedEvents', 'emitTo', 'executeHandler', 'executePostHandler', 'getConcurrentEvents']);
         this.eventSpy.attachedEvents = [];
         this.eventSpy.getConcurrentEvents.and.returnValue([]);
         this.eventWindow = new EventWindow(this.gameSpy, this.eventSpy);
@@ -16,10 +16,10 @@ describe('EventWindow', function() {
                 this.eventWindow.continue();
             });
 
-            it('should emit all of the interrupt/reaction events', function() {
-                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: this.eventSpy });
-                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: this.eventSpy });
-                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: this.eventSpy });
+            it('should emit all of the reaction events', function() {
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelreaction', event: this.eventSpy });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'traitinsteadreaction', event: this.eventSpy });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'insteadreaction', event: this.eventSpy });
                 expect(this.eventSpy.emitTo).toHaveBeenCalledWith(this.gameSpy);
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'traitreaction', event: this.eventSpy });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: this.eventSpy });
@@ -32,8 +32,7 @@ describe('EventWindow', function() {
 
         describe('when a concurrent event can be saved', function() {
             beforeEach(function() {
-                this.concurrentEventSpy = jasmine.createSpyObj('concurrentEvent', ['allowAutomaticSave', 'cancel', 'clearAttachedEvents']);
-                this.concurrentEventSpy.allowAutomaticSave.and.returnValue(true);
+                this.concurrentEventSpy = jasmine.createSpyObj('concurrentEvent', ['cancel', 'clearAttachedEvents']);
                 this.concurrentEventSpy.attachedEvents = [];
                 this.concurrentEventSpy.card = { card: 1 };
                 this.eventSpy.card = { card: 2 };
@@ -61,10 +60,10 @@ describe('EventWindow', function() {
                 this.eventSpy.cancelled = true;
             });
 
-            it('should not emit the post-cancel interrupt/reaction events', function() {
+            it('should not emit the post-cancel reaction events', function() {
                 this.eventWindow.continue();
-                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: this.eventSpy });
-                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'interrupt', event: this.eventSpy });
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'traitinsteadreaction', event: this.eventSpy });
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'insteadreaction', event: this.eventSpy });
                 expect(this.eventSpy.emitTo).not.toHaveBeenCalled();
                 expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'traitreaction', event: this.eventSpy });
                 expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'reaction', event: this.eventSpy });
@@ -96,10 +95,10 @@ describe('EventWindow', function() {
                 this.eventWindow.continue();
             });
 
-            it('should emit all of the interrupt events', function() {
-                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: this.eventSpy });
-                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: this.eventSpy });
-                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: this.eventSpy });
+            it('should emit all of the reactions(before) events', function() {
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelreaction', event: this.eventSpy });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'traitinsteadreaction', event: this.eventSpy });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'insteadreaction', event: this.eventSpy });
             });
 
             it('should not emit the post-cancel  events', function() {


### PR DESCRIPTION
Contains big refactor of throneteki's interrupts. Created new classes for "cancel reactions", "instead reactions" or reactions that go before the event.
Fixed `SendHome` action that did not execute at home and some other small fixes.
Implemented new card `Lay On Hands` that uses new "instead reaction".