### PR TITLE
Card: Owl's Insight

### DIFF
--- a/docs/cardpool-status.md
+++ b/docs/cardpool-status.md
@@ -1,6 +1,6 @@
 # Card implementation status
 
-![Cards implemented](https://progress-bar.dev/262/?scale=875&title=implemented%20&width=200&suffix=%20cards) out of 875
+![Cards implemented](https://progress-bar.dev/264/?scale=875&title=implemented%20&width=200&suffix=%20cards) out of 875
 
 **Legend**
 
@@ -502,7 +502,7 @@
 |:heavy_check_mark:   | 12015| Guide Horse
 |                     | 12016| Marty
 |                     | 12017| Righteous Fury
-|                     | 12018| Owl's Insight
+|:heavy_check_mark:   | 12018| Owl's Insight
 |                     | 12019| Outgunned
 |                     | 12020| Martyr's Cry
 |                     | 12021| Deliberate Infection
@@ -540,7 +540,7 @@
 |                     | 14001| Carlton "Min" Rutherford
 |                     | 14002| Lucretia Fanzini
 |                     | 14003| Rhonda Sageblossom
-|                     | 14004| Francisco Rosales
+|:heavy_check_mark:   | 14004| Francisco Rosales
 |                     | 14005| Ambrose Douglas
 |                     | 14006| Constance Daughtry
 |                     | 14007| Tallulah "Lula" Morgan (Exp.1)

--- a/server/game/cards/07.2-FP/OwlsInsight.js
+++ b/server/game/cards/07.2-FP/OwlsInsight.js
@@ -18,8 +18,8 @@ class OwlsInsight extends SpellCard {
     processSpellOrGoods(context) {
         if(!this.doneSelecting) {
             this.game.promptForSelect(context.player, {
-                activePromptTitle: 'Select goods or spells to attach',
-                waitingPromptTitle: 'Waiting for opponent to select goods or spells',
+                activePromptTitle: 'Select goods or spell to attach',
+                waitingPromptTitle: 'Waiting for opponent to select goods or spell',
                 cardCondition: card => card.location === 'hand' && card.owner === context.player,
                 cardType: ['goods', 'spell'],
                 onSelect: (player, card) => {

--- a/server/game/cards/07.2-FP/OwlsInsight.js
+++ b/server/game/cards/07.2-FP/OwlsInsight.js
@@ -9,19 +9,42 @@ class OwlsInsight extends SpellCard {
             cost: ability.costs.bootSelf(),
             difficulty: 5,
             onSuccess: (context) => {
-                this.game.promptForSelect(context.player, {
-                    activePromptTitle: 'Select goods or spells to attach',
-                    waitingPromptTitle: 'Waiting for opponent to select goods or spells',
-                    cardCondition: card => card.location === 'hand' && card.owner === context.player,
-                    cardType: ['goods', 'spell'],
-                    multiSelect: true,
-                    numCards: 0,
-                    onSelect: (player, cards) => {
-                        cards.map(card => this.game.resolveStandardAbility(StandardActions.putIntoPlayWithReduction(1), player, card));
-                    }
-                });
+                this.doneSelecting = false;
+                this.owlAction(context);
             }
         });
+    }
+
+    processSpellOrGoods(context) {
+        if(!this.doneSelecting) {
+            this.game.promptForSelect(context.player, {
+                activePromptTitle: 'Select goods or spells to attach',
+                waitingPromptTitle: 'Waiting for opponent to select goods or spells',
+                cardCondition: card => card.location === 'hand' && card.owner === context.player,
+                cardType: ['goods', 'spell'],
+                onSelect: (player, card) => {
+                    this.game.resolveStandardAbility(StandardActions.putIntoPlayWithReduction(1), player, card);
+                    this.game.queueSimpleStep(() => {
+                        this.owlAction(context);
+                    });
+                    return true;
+                },
+                onCancel: () => {
+                    this.doneSelecting = true;
+                    context.player.redrawToHandSize();
+                },
+                source: this
+            });
+        }
+    }
+
+    owlAction(context) {
+        const spellsAndGoodsNumber = context.player.hand.filter(card => ['spell', 'goods'].includes(card.getType())).length;
+        if(spellsAndGoodsNumber > 0 && !this.doneSelecting) {
+            this.processSpellOrGoods(context);
+        } else {
+            context.player.redrawToHandSize();
+        }
     }
 }
 

--- a/server/game/cards/07.2-FP/OwlsInsight.js
+++ b/server/game/cards/07.2-FP/OwlsInsight.js
@@ -1,0 +1,30 @@
+const SpellCard = require('../../spellcard.js');
+const StandardActions = require('../../PlayActions/StandardActions.js');
+
+class OwlsInsight extends SpellCard {
+    setupCardAbilities(ability) {
+        this.spellAction({
+            title: 'Owl\'s Insight',
+            playType: 'cheatin resolution',
+            cost: ability.costs.bootSelf(),
+            difficulty: 5,
+            onSuccess: (context) => {
+                this.game.promptForSelect(context.player, {
+                    activePromptTitle: 'Select goods or spells to attach',
+                    waitingPromptTitle: 'Waiting for opponent to select goods or spells',
+                    cardCondition: card => card.location === 'hand' && card.owner === context.player,
+                    cardType: ['goods', 'spell'],
+                    multiSelect: true,
+                    numCards: 0,
+                    onSelect: (player, cards) => {
+                        cards.map(card => this.game.resolveStandardAbility(StandardActions.putIntoPlayWithReduction(1), player, card));
+                    }
+                });
+            }
+        });
+    }
+}
+
+OwlsInsight.code = '12018';
+
+module.exports = OwlsInsight;

--- a/server/game/gamesteps/sundownphase.js
+++ b/server/game/gamesteps/sundownphase.js
@@ -19,7 +19,7 @@ class SundownPhase extends Phase {
 
     sundownRedraw() {
         this.game.getPlayers().forEach(player => {
-            player.sundownRedraw();
+            player.redrawToHandSize('sundown');
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -507,8 +507,8 @@ class Player extends Spectator {
         this.handResult = new HandResult();
     }
 
-    sundownRedraw() {
-        this.drawCardsToHand(this.handSize - this.hand.length, null, 'sundown');
+    redrawToHandSize(reason) {
+        this.drawCardsToHand(this.handSize - this.hand.length, null, reason);
     }
 
     isOverHandsizeLimit() {


### PR DESCRIPTION
The card works, but if you select multiple attachments at once, there is no indication of which one you are attaching, so you have to remember which order you selected them in. Once you've selected a good or spell, it prompts you again. If you select them one at a time, it works ok, but I'm not sure how to either force the goods/spell selection and attachment to happen one at a time and re-prompt or to allow multiselect and have the attachment prompt state the name of the card you're attaching.