### PR TITLE
Fix issues after COMICCON plays

### DIFF
--- a/server/game/PropertyTypes/KeywordsProperty.js
+++ b/server/game/PropertyTypes/KeywordsProperty.js
@@ -51,7 +51,7 @@ class KeywordsProperty {
     }
 
     addKeyword(keyword, isPrinted = false) {
-        let results = /([a-z A-Z]+)(\d*)$/.exec(keyword.toLowerCase().trim());  
+        let results = /([a-z A-Z-]+)(\d*)$/.exec(keyword.toLowerCase().trim());  
         if(results) {
             this.add(results[1].trim());
             if(isPrinted) {

--- a/server/game/cards/13-O4B/MasonAdler.js
+++ b/server/game/cards/13-O4B/MasonAdler.js
@@ -5,7 +5,8 @@ class MasonAdler extends DudeCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            effect: ability.effects.cannotAttachCards(this, attachment => !attachment.hasKeyword('melee'))
+            effect: ability.effects.cannotAttachCards(this, attachment => 
+                attachment.hasKeyword('weapon') && !attachment.hasKeyword('melee'))
         });
 
         this.job({

--- a/server/game/cards/14-HCWM/JackieSanjuro.js
+++ b/server/game/cards/14-HCWM/JackieSanjuro.js
@@ -14,7 +14,8 @@ class JackieSanjuro extends DudeCard {
 
         this.persistentEffect({
             match: this,
-            effect: ability.effects.cannotAttachCards(this, attachment => !attachment.hasKeyword('melee'))
+            effect: ability.effects.cannotAttachCards(this, attachment => 
+                attachment.hasKeyword('weapon') && !attachment.hasKeyword('melee'))
         });
     }
 }

--- a/server/game/gamelocation.js
+++ b/server/game/gamelocation.js
@@ -57,21 +57,23 @@ class GameLocation {
         playersStats.set(this.locationCard.controllingPlayer.name, 0);
         this.occupants.forEach(dudeUuid => {
             let dude = this.game.findCardInPlayByUuid(dudeUuid);
-            let determinator = defaultDeterminator;
-            if(dude.controlDeterminator !== 'influence:deed') {
-                determinator = dude.controlDeterminator;
-            }
-            let amount = dude.getStat(determinator);
-            if(amount > 0) {
-                let currentAmount = playersStats.get(dude.controller.name) || 0;
-                playersStats.set(dude.controller.name, currentAmount + amount);
-                if(dude.controller.name === playerWithMost.name) {
-                    currentController = dude.controller;
-                } else if(playersStats.get(dude.controller.name) > playersStats.get(playerWithMost.name)) {
-                    playerWithMost = dude.controller;
-                    currentController = dude.controller;
-                } else if(playersStats.get(dude.controller.name) === playersStats.get(playerWithMost.name)) {
-                    currentController = this.locationCard.owner;
+            if(dude) {
+                let determinator = defaultDeterminator;
+                if(dude.controlDeterminator !== 'influence:deed') {
+                    determinator = dude.controlDeterminator;
+                }
+                let amount = dude.getStat(determinator);
+                if(amount > 0) {
+                    let currentAmount = playersStats.get(dude.controller.name) || 0;
+                    playersStats.set(dude.controller.name, currentAmount + amount);
+                    if(dude.controller.name === playerWithMost.name) {
+                        currentController = dude.controller;
+                    } else if(playersStats.get(dude.controller.name) > playersStats.get(playerWithMost.name)) {
+                        playerWithMost = dude.controller;
+                        currentController = dude.controller;
+                    } else if(playersStats.get(dude.controller.name) === playersStats.get(playerWithMost.name)) {
+                        currentController = this.locationCard.owner;
+                    }
                 }
             }
         });

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -695,8 +695,6 @@ class Player extends Spectator {
     }
 
     canControl(card) {
-        let owner = card.owner;
-
         if(!card.isUnique()) {
             return true;
         }
@@ -705,23 +703,11 @@ class Player extends Spectator {
             return false;
         }
 
-        if(owner === this) {
-            let controlsAnOpponentsCopy = this.anyCardsInPlay(c => c.title === card.title && c.owner !== this && !c.facedown);
-            let opponentControlsOurCopy = this.game.getPlayers().some(player => {
-                return player !== this && player.anyCardsInPlay(c => c.title === card.title && c.owner === this && c !== card && !c.facedown);
-            });
-
-            return !controlsAnOpponentsCopy && !opponentControlsOurCopy;
+        if(card.owner === this) {
+            return !this.anyCardsInPlay(c => c.title === card.title && c.owner === this && !c.facedown);
         }
 
-        if(owner.isAced(card)) {
-            return false;
-        }
-
-        let controlsACopy = this.anyCardsInPlay(c => c.title === card.title && !c.facedown);
-        let opponentControlsACopy = owner.anyCardsInPlay(c => c.title === card.title && c !== card && !c.facedown);
-
-        return !controlsACopy && !opponentControlsACopy;
+        return true;
     }
 
     putIntoPlay(card, params = {}) {


### PR DESCRIPTION
Fix some other bugs:
- incorrect attachment restrictions for Mason Adler and Jackie Sanjuro
- crashing causing by specific situations when dudes in a game location were no longer in play
- players not able to put deeds in play which they already controller on the opponent's street
- incorrect paring of `non-unique` keyword causing that non-unique dudes could not be put into play if they were already in boot hill