### PR TITLE
Fix gadget inventing via cards

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -860,8 +860,7 @@ class Player extends Spectator {
                     card.controller === this &&
                     !card.cannotInventGadgets() &&
                     (!card.booted || gadget.canBeInventedWithoutBooting()) &&
-                    card.canPerformSkillOn(gadget) &&
-                    card.isInControlledLocation(),
+                    card.canPerformSkillOn(gadget),
                 cardType: 'dude',
                 onSelect: (player, card) => {
                     if(!gadget.canBeInventedWithoutBooting()) {


### PR DESCRIPTION
Gadget inventing via cards should not require Mad Scientists to be in a controlled location.