### PR TITLE
Card: The Extra Bet, De Annulos Mysteriis

### DIFF
--- a/docs/cardpool-status.md
+++ b/docs/cardpool-status.md
@@ -430,7 +430,7 @@
 |                     | 10017| Sloane (Exp.1)
 |                     | 10018| Margaret Hagerty
 |                     | 10019| The Wretched
-|                     | 10020| The Extra Bet
+|:heavy_check_mark:   | 10020| The Extra Bet
 |                     | 10021| Morgan Mining Company
 |                     | 10022| Quarantine Tent
 |:heavy_check_mark:   | 10023| Cooke's Nightcap
@@ -690,7 +690,7 @@
 |:heavy_check_mark:   | 18027| Bowie Knife
 |:heavy_check_mark:   | 18028| Hydro-Puncher
 |                     | 18029| Rancher's Lariat
-|                     | 18030| De Annulos Mysteriis
+|:heavy_check_mark:   | 18030| De Annulos Mysteriis
 |                     | 18031| Heartseeker
 |                     | 18032| Tse-Che-Nako's Weaving
 |:heavy_check_mark:   | 18033| Amazing Grace

--- a/server/game/cards/06-TLS/TheExtraBet.js
+++ b/server/game/cards/06-TLS/TheExtraBet.js
@@ -1,0 +1,45 @@
+const DeedCard = require('../../deedcard.js');
+const GameActions = require('../../GameActions/index.js');
+
+class TheExtraBet extends DeedCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            title: 'React The Extra Bet',
+            when: {
+                onPlayersAntedForLowball: () => this.controller.getSpendableGhostRock() >= 1
+            },
+            cost: ability.costs.bootSelf(),
+            message: context => 
+                this.game.addMessage('{0} uses {1} to ante additional GR for lowball', context.player, this),
+            handler: context => {
+                context.player.spendGhostRock(1);
+                context.event.gamblingPhase.lowballPot += 1;
+                this.game.onceConditional('onCardsDrawn', { 
+                    condition: event => event.reason === 'lowball' && event.player === context.player
+                }, () => {
+                    this.game.promptForSelect(context.player, {
+                        activePromptTitle: 'Select a card to replace',
+                        waitingPromptTitle: 'Waiting for opponent to select card',
+                        cardCondition: card => card.location === 'draw hand' && card.owner === context.player,
+                        onSelect: (player, cardToDiscard) => {
+                            this.game.resolveGameAction(GameActions.discardCard({ card: cardToDiscard }), context).thenExecute(() => {
+                                if(!player.drawDeck.length) {
+                                    player.shuffleDiscardToDrawDeck();
+                                }
+                                player.moveCard(player.drawDeck[0], 'draw hand');
+                                this.game.addMessage('{0} uses {1} to discard {2} from their draw hand and replace it ' +
+                                'with the top card of their deck', context.player, this, cardToDiscard);
+                            });
+                            return true;
+                        },
+                        source: this
+                    });
+                });
+            }
+        });
+    }
+}
+
+TheExtraBet.code = '10020';
+
+module.exports = TheExtraBet;

--- a/server/game/cards/10-BMR/DeAnnulosMysteriis.js
+++ b/server/game/cards/10-BMR/DeAnnulosMysteriis.js
@@ -1,0 +1,56 @@
+const GoodsCard = require('../../goodscard.js');
+const JobAction = require('../../jobaction.js');
+
+class DeAnnulosMysteriis extends GoodsCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Noon: De Annulos Mysteriis',
+            playType: ['noon'],
+            cost: ability.costs.aceSelf(),
+            target: {
+                activePromptTitle: 'Select Job card marking location',
+                cardCondition: { 
+                    location: 'discard pile', 
+                    controller: 'current', 
+                    condition: card => this.isJobActionCard(card) 
+                },
+                cardType: ['action']
+            },
+            message: context => 
+                this.game.addMessage('{0} uses {1} and aces it to play {2} from discard', 
+                    context.player, this, context.target),
+            handler: context => {
+                const eventHandler = event => {
+                    this.untilEndOfShootoutPhase(context.ability, ability => ({
+                        match: event.shootout.leader,
+                        effect: [
+                            ability.effects.setAsStud(),
+                            ability.effects.modifyBullets(1)
+                        ]
+                    }));
+                    this.game.addMessage('{0} makes {1} a stud and gives them +1 bullets thanks to {2}', 
+                        context.player, event.shootout.leader, this);
+                };
+                this.game.once('onShootoutPhaseStarted', eventHandler);
+
+                context.player.moveCardWithContext(context.target, 'hand', context);
+                context.target.useAbility(context.player, { 
+                    doNotMarkActionAsTaken: true
+                });
+                this.game.onceConditional('onCardAbilityResolved', { condition: event => event.ability === context.ability },
+                    () => this.game.removeListener('onShootoutPhaseStarted', eventHandler));
+            }
+        });
+    }
+
+    isJobActionCard(card) {
+        if(card.getType() !== 'action') {
+            return false;
+        }
+        return card.abilities.actions.some(action => action instanceof JobAction);
+    }
+}
+
+DeAnnulosMysteriis.code = '18030';
+
+module.exports = DeAnnulosMysteriis;

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -239,7 +239,7 @@ class ChatCommands {
             activePromptTitle: 'Select a card to set production for',
             waitingPromptTitle: 'Waiting for opponent to set production',
             cardCondition: card => card.location === 'play area' && card.controller === player,
-            cardType: ['dude', 'goods', 'deed'],
+            cardType: ['dude', 'goods', 'deed', 'outfit'],
             onSelect: (p, card) => {
                 let prod = modifier.mod;
                 if(modifier.set !== undefined && modifier.set !== null) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1101,8 +1101,8 @@ class Game extends EventEmitter {
         this.getPlayers().forEach(player => player.discardDrawHand());
     }
 
-    drawHands(numberToDraw = 5) {
-        this.getPlayers().forEach(player => player.drawCardsToDrawHand(numberToDraw));
+    drawHands(numberToDraw = 5, context, reason) {
+        this.getPlayers().forEach(player => player.drawCardsToDrawHand(numberToDraw, context, reason));
     }
 
     revealHands() {

--- a/server/game/gamesteps/gamblingphase.js
+++ b/server/game/gamesteps/gamblingphase.js
@@ -11,7 +11,7 @@ class GamblingPhase extends Phase {
 
         this.initialise([
             new SimpleStep(game, () => this.ante()),
-            new SimpleStep(game, () => this.game.drawHands()),
+            new SimpleStep(game, () => this.game.drawHands(5, null, 'lowball')),
             // TODO M2 Shootout testing - comment out DrawHandPrompt and cheatinResolutions
             new DrawHandPrompt(game),
             new SimpleStep(game, () => this.game.revealHands()),
@@ -31,6 +31,7 @@ class GamblingPhase extends Phase {
             }
             this.lowballPot++;
         });
+        this.game.raiseEvent('onPlayersAntedForLowball', { gamblingPhase: this });
     }
 
     cheatinResolutions() {

--- a/server/game/gamesteps/shootout.js
+++ b/server/game/gamesteps/shootout.js
@@ -161,7 +161,7 @@ class Shootout extends Phase {
         for(const player of this.game.getPlayers()) {
             player.phase = this.name;
         }        
-        this.game.raiseEvent('onShootoutPhaseStarted');
+        this.game.raiseEvent('onShootoutPhaseStarted', { shootout: this });
         let phaseName = this.isJob() ? 'Job' : 'Shootout';
         this.game.addAlert('phasestart', phaseName + ' started!');        
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -335,11 +335,12 @@ class Player extends Spectator {
         }), this.createContext(context));
     }
 
-    drawCardsToDrawHand(numCards = 1, context) {
+    drawCardsToDrawHand(numCards = 1, context, reason) {
         return this.game.resolveGameAction(GameActions.drawCards({
             player: this,
             amount: numCards,
-            target: 'draw hand'
+            target: 'draw hand',
+            reason
         }), this.createContext(context));
     }
 
@@ -413,14 +414,6 @@ class Player extends Spectator {
         }, options, context);
     }
 
-    moveFromTopToBottomOfDrawDeck(number) {
-        while(number > 0) {
-            this.moveCard(this.drawDeck[0], 'draw deck', { bottom: true });
-
-            number--;
-        }
-    }
-
     discardAtRandom(number, callback = () => true) {
         var toDiscard = Math.min(number, this.hand.length);
         var cards = [];
@@ -438,11 +431,6 @@ class Player extends Spectator {
             this.game.addMessage('{0} discards {1} at random', this, discarded);
             callback(discarded);
         });
-    }
-
-    // TODO M2 can be probably removed
-    canDraw() {
-        return (this.maxCardDraw.getMax() === undefined || this.drawnCards < this.maxCardDraw.getMax());
     }
 
     resetCardPile(pile) {

--- a/test/server/GameActions/DrawCards.spec.js
+++ b/test/server/GameActions/DrawCards.spec.js
@@ -2,7 +2,7 @@ const DrawCards = require('../../../server/game/GameActions/DrawCards');
 
 describe('DrawCards', function() {
     beforeEach(function() {
-        this.playerSpy = jasmine.createSpyObj('player', ['canDraw', 'getNumCardsToDraw', 'placeCardInPile', 'shuffleDiscardToDrawDeck', 'drawDeckAction']);
+        this.playerSpy = jasmine.createSpyObj('player', ['getNumCardsToDraw', 'placeCardInPile', 'shuffleDiscardToDrawDeck', 'drawDeckAction']);
         this.playerSpy.getNumCardsToDraw.and.returnValue(2);
         this.playerSpy.drawDeck = ['card1', 'card2'];
         this.playerSpy.discardPile = [];


### PR DESCRIPTION
De Annulos Mysteriis does not restrict targeting as it should based on the card text:
 - filters only job cards in discard, does not check if they are targeting location
 - let's player select job leader even though it should be dude that has De Annulos Mysteriis attached if able

This was not done because that additional targeting would require quite big changes that would be needed only for this card which will not be in the new format (Weird West).