### PR TITLE
Remove Info message for Deed controller change

### DIFF
--- a/server/game/gamelocation.js
+++ b/server/game/gamelocation.js
@@ -77,13 +77,6 @@ class GameLocation {
                 }
             }
         });
-        if(currentController !== originalController) {
-            if(currentController !== this.locationCard.owner) {
-                this.game.addAlert('info', '{0} broke into {1} and has taken control from the {2}.', currentController, this.locationCard, originalController);
-            } else {
-                this.game.addAlert('info', '{0} has wrestled control of {1} back from {2}.', currentController, this.locationCard, originalController);
-            }
-        }
         return currentController;
     }
 


### PR DESCRIPTION
We will have to get rid of those nice messages about breaking into deeds when control changes. There are specific scenarios (e.g. Auto-Gatling) that causes the control is internally changed multiple times resulting in message spam in chat. Result is always correct, and deed is properly highlighted, but a lot of messages (around 20) are added to chat.