### PR TITLE
Fix OoT deeds moving to street

### DIFF
--- a/server/game/gamelocation.js
+++ b/server/game/gamelocation.js
@@ -49,7 +49,6 @@ class GameLocation {
             return;
         }
         let playersStats = new Map();
-        let originalController = this.locationCard.controllingPlayer;
         let playerWithMost = this.locationCard.owner;
         let currentController = this.locationCard.owner;
         let defaultDeterminator = this.locationCard.controlDeterminator;
@@ -109,6 +108,10 @@ class GameLocation {
 
     isHome(player) {
         return this.isOutfit() && this.locationCard.owner === player;
+    }
+
+    isOutOfTown() {
+        return this.locationCard.hasKeyword('out of town');
     }
 
     isOpponentsHome(player) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1224,7 +1224,8 @@ class Player extends Spectator {
             }
         });
         this.game.queueSimpleStep(() => {
-            this.locations = this.locations.filter(loc => loc !== gameLocation);
+            const outOfTownLocations = this.locations.filter(loc => loc.isOutOfTown());
+            this.locations = this.locations.filter(loc => loc !== gameLocation && !loc.isOutOfTown());
             if(!card.isOutOfTown()) {
                 const orderedLocations = this.locations.sort((a, b) => {
                     return a.order - b.order;
@@ -1251,6 +1252,7 @@ class Player extends Spectator {
                     }
                 }
             }
+            this.locations = this.locations.concat(outOfTownLocations);
         });
     }
 


### PR DESCRIPTION
When removing a deed from a street, the reordering logic is working also with OoT deeds and thus putting them to street.
This is fixed in a way that OoT deeds are separated when reordering.