### PR TITLE
Draw hand popup updates

### DIFF
--- a/server/game/gamesteps/shootout/drawhandprompt.js
+++ b/server/game/gamesteps/shootout/drawhandprompt.js
@@ -43,7 +43,8 @@ class DrawHandPrompt extends UiPrompt {
                 buttons: [
                     { arg: 'redraw', text: 'Done' }
                 ],
-                selectCard: true
+                selectCard: true,
+                popupStayOpen: true
             };
         } 
         return {

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -2,6 +2,7 @@ class PlayerPromptState {
     constructor() {
         this.selectCard = false;
         this.selectOrder = false;
+        this.popupStayOpen = false;
         this.menuTitle = '';
         this.promptTitle = '';
         this.buttons = [];
@@ -30,6 +31,7 @@ class PlayerPromptState {
     setPrompt(prompt) {
         this.selectCard = prompt.selectCard || false;
         this.selectOrder = prompt.selectOrder || false;
+        this.popupStayOpen = prompt.popupStayOpen || false;
         this.menuTitle = prompt.menuTitle || '';
         this.promptTitle = prompt.promptTitle;
         this.buttons = (prompt.buttons || []).map(button => {
@@ -74,6 +76,7 @@ class PlayerPromptState {
         return {
             selectCard: this.selectCard,
             selectOrder: this.selectOrder,
+            popupStayOpen: this.popupStayOpen,
             menuTitle: this.menuTitle,
             promptTitle: this.promptTitle,
             buttons: this.buttons.map(button => this.getButtonState(button)),


### PR DESCRIPTION
Add prompt property to let UI know the popup should stay opened after the card selection.

fixes townteki/townsquare-client#39
Resolves part of the townteki/townsquare-client#18

The UI part of this change is in PR townteki/townsquare-client#84