### PR TITLE
ignore CORS checks in dev mode.

### DIFF
--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -62,6 +62,14 @@ class GameServer {
             options.path = '/' + (process.env.SERVER || config.nodeIdentity) + '/socket.io';
         }
 
+        // ignore CORS in dev mode
+        // @link https://socket.io/docs/v2/handling-cors/
+        if(process.env.NODE_ENV === 'development') {
+            options.allowRequest = (req, callback) => {
+                callback(null, true);
+            };
+        }
+
         this.io = socketio(server, options);
         this.io.set('heartbeat timeout', 30000);
         this.io.use(this.handshake.bind(this));


### PR DESCRIPTION
this gets around any CORS checks when developing.

alternatively, we could hard wire in  a whitelist of domains for dev mode, like so:

```js
if (process.env.NODE_ENV === 'development') {
    this.io.set('origins', 'http://localhost:8080');
}
```

but that may be making too many assumptions about the given dev environment. 

as a follow-up item, the `origins` setting may be best extracted out into application config/env  vars or the likes. no magic strings!