### PR TITLE
Fix pulled card handling

### DIFF
--- a/server/game/cards/10-BMR/108DrunkenMasters.js
+++ b/server/game/cards/10-BMR/108DrunkenMasters.js
@@ -28,7 +28,10 @@ class DrunkenMasters extends OutfitCard {
                     this.game.promptForYesNo(context.player, {
                         title: `Do you want to put ${event.pulledCard.title} into your hand?`,
                         onYes: player => {
-                            event.context.pull.doNotHandlePulledCard = true;
+                            if(event.context.pull) {
+                                // set the flag to prevent discarding of pulled card in abilityresolver
+                                event.context.pull.doNotHandlePulledCard = true;
+                            }
                             this.game.before('onPulledCardHandled', handleEvent => {
                                 handleEvent.replaceHandler(() => true);
                             }, true, handleEvent => 

--- a/server/game/cards/10-BMR/108DrunkenMasters.js
+++ b/server/game/cards/10-BMR/108DrunkenMasters.js
@@ -28,8 +28,7 @@ class DrunkenMasters extends OutfitCard {
                     this.game.promptForYesNo(context.player, {
                         title: `Do you want to put ${event.pulledCard.title} into your hand?`,
                         onYes: player => {
-                            // set to null to prevent discarding of pulled card in abilityresolver
-                            event.context.pull = null;
+                            event.context.pull.doNotHandlePulledCard = true;
                             this.game.before('onPulledCardHandled', handleEvent => {
                                 handleEvent.replaceHandler(() => true);
                             }, true, handleEvent => 

--- a/server/game/cards/11-TCaR/EzekiahGrimme.js
+++ b/server/game/cards/11-TCaR/EzekiahGrimme.js
@@ -26,8 +26,7 @@ class EzekiahGrimme extends LegendCard {
             },
             cost: [ability.costs.bootSelf()],
             handler: context => {
-                // set to null to prevent discarding of pulled card in abilityresolver
-                context.event.context.pull = null;
+                context.event.context.pull.doNotHandlePulledCard = true;
                 this.game.promptForYesNo(context.player, {
                     title: 'Do you want to attach pulled Spell?',
                     onYes: player => {
@@ -42,7 +41,8 @@ class EzekiahGrimme extends LegendCard {
                     },
                     onNo: player => {
                         player.handlePulledCard(context.event.pulledCard);
-                    }
+                    },
+                    source: this
                 });
             }
         });

--- a/server/game/cards/11-TCaR/EzekiahGrimme.js
+++ b/server/game/cards/11-TCaR/EzekiahGrimme.js
@@ -26,7 +26,10 @@ class EzekiahGrimme extends LegendCard {
             },
             cost: [ability.costs.bootSelf()],
             handler: context => {
-                context.event.context.pull.doNotHandlePulledCard = true;
+                if(context.event.context.pull) {
+                    // set the flag to prevent discarding of pulled card in abilityresolver
+                    context.event.context.pull.doNotHandlePulledCard = true;
+                }
                 this.game.promptForYesNo(context.player, {
                     title: 'Do you want to attach pulled Spell?',
                     onYes: player => {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -266,7 +266,7 @@ class AbilityResolver extends BaseStep {
 
             this.game.resolveEvent(event);
         }
-        if(this.context.pull) {
+        if(this.context.pull && !this.context.pull.doNotHandlePulledCard) {
             this.context.pull.pulledCard.owner.handlePulledCard(this.context.pull.pulledCard);
         }
         if(this.ability.isCardAbility()) {


### PR DESCRIPTION
This is for cards:
- 108 Drunken Masters
- Ezekiah Grimme

Was causing `TypeError: Cannot read property 'isSuccessful' of null` at `AbilityResolver.raiseOnAbilityResolvedEvent`