### PR TITLE
Set default suit and update Rosenbaum's Golem

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -98,7 +98,7 @@ class BaseCard {
     }
 
     get suit() {
-        return this.suitReferenceArray[0].suit;
+        return this.suitReferenceArray[0].suit || '';
     }
 
     get bullets() {

--- a/server/game/cards/11-TCaR/RosenbaumsGolem.js
+++ b/server/game/cards/11-TCaR/RosenbaumsGolem.js
@@ -9,7 +9,7 @@ class RosenbaumsGolem extends DudeCard {
             playType: ['shootout'],
             target: {
                 activePromptTitle: 'Choose an opposing dude',
-                cardCondition: { location: 'play area', controller: 'opponent' },
+                cardCondition: { location: 'play area', controller: 'opponent', participating: true },
                 cardType: ['dude'],
                 gameAction: 'boot'
             },


### PR DESCRIPTION
The default suit for Joker was null causing troubles for some cards (e.g. Smiling Frog).