### PR TITLE
Random Fixes 3

### DIFF
--- a/server/game/cards/01-DTR/RailroadStation.js
+++ b/server/game/cards/01-DTR/RailroadStation.js
@@ -15,8 +15,12 @@ class RailroadStation extends DeedCard {
             },
             handler: context => {
                 this.game.promptForLocation(context.player, {
-                    activePromptTitle: 'Select destination',
+                    activePromptTitle: 'Select destination for ' + context.target.title,
                     waitingPromptTitle: 'Waiting for opponent to select location',
+                    cardCondition: {
+                        location: 'play area',
+                        condition: card => !card.equals(this)
+                    },
                     onSelect: (player, location) => {
                         this.game.resolveGameAction(GameActions.moveDude({ 
                             card: context.target, 

--- a/server/game/cards/02.1-NTNR/BackWays.js
+++ b/server/game/cards/02.1-NTNR/BackWays.js
@@ -31,6 +31,7 @@ class BackWays extends ActionCard {
                         }), context);
                         this.game.addMessage('{0} uses {1} to move {2} from {3} to {4}',
                             player, this, context.target, erstwhileLocation, location);
+                        return true;
                     },
                     source: this
                 });

--- a/server/game/cards/04.1-FJ/TheFlyingPopescus.js
+++ b/server/game/cards/04.1-FJ/TheFlyingPopescus.js
@@ -3,7 +3,7 @@ const DudeCard = require('../../dudecard.js');
 class TheFlyingPopescus extends DudeCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.getAttachmentsByKeywords('hex').length >= 2,
+            condition: () => this.getAttachmentsByKeywords(['hex']).length >= 2,
             match: this,
             effect: ability.effects.modifyInfluence(1)
         });

--- a/server/game/cards/04.1-FJ/TheFlyingPopescus.js
+++ b/server/game/cards/04.1-FJ/TheFlyingPopescus.js
@@ -3,7 +3,7 @@ const DudeCard = require('../../dudecard.js');
 class TheFlyingPopescus extends DudeCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.getAttachmentsByKeywords(['hex']).length >= 2,
+            condition: () => this.getAttachmentsByKeywords('hex').length >= 2,
             match: this,
             effect: ability.effects.modifyInfluence(1)
         });

--- a/server/game/cards/08-GT/Tusk.js
+++ b/server/game/cards/08-GT/Tusk.js
@@ -1,6 +1,11 @@
 const GoodsCard = require('../../goodscard.js');
 
 class Tusk extends GoodsCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+        this.registerEvents(['onAbilityTargetsResolution']);
+    }
+
     setupCardAbilities() {
         this.traitReaction({
             when: {
@@ -11,20 +16,20 @@ class Tusk extends GoodsCard {
                 context.player.drawCardsToHand(1, context);
             }
         });
-        this.traitReaction({
-            when: {
-                onAbilityTargetsResolution: event => event.ability.isCardAbility() && event.player === this.controller.getOpponent()
+    }
+
+    onAbilityTargetsResolution(targetResEvent) {
+        if(!targetResEvent.ability.isCardAbility() || targetResEvent.player !== this.controller.getOpponent() || 
+            this.isFullBlank() || this.isTraitBlank()) {
+            return;
+        }
+        this.lastingEffect(targetResEvent.ability, ability => ({
+            until: {
+                onCardAbilityResolved: event => event.ability === targetResEvent.ability
             },
-            handler: context => {
-                this.lastingEffect(context.ability, ability => ({
-                    until: {
-                        onCardAbilityResolved: event => event.ability === context.event.ability
-                    },
-                    match: this.parent,
-                    effect: ability.effects.modifyValue(5)
-                }));
-            }
-        });
+            match: this.parent,
+            effect: ability.effects.modifyValue(5)
+        }));
     }
 }
 

--- a/server/game/cards/09.1-TCR/HighStakesHaven.js
+++ b/server/game/cards/09.1-TCR/HighStakesHaven.js
@@ -7,19 +7,38 @@ class HighStakesHaven extends DeedCard {
                 onDrawHandsRevealed: () => this.controller.isCheatin()
             },
             handler: () => {
-                if(this.controller.getSpendableGhostRock() <= 0) {
-                    this.havenRandomDiscard();
-                } else if(this.controller.hand.length) {
-                    this.game.promptWithMenu(this.controller, this, {
-                        activePrompt: {
-                            menuTitle: 'Choose cheatin\' punishment',
-                            buttons: [
-                                { text: 'Pay 1 GR', method: 'payGR' },
-                                { text: 'Discard card', method: 'havenRandomDiscard' }
-                            ]
-                        },
-                        source: this
-                    });
+                let choicemask = 0;
+                if(this.controller.getSpendableGhostRock() >= 1) {
+                    choicemask = choicemask | 1;
+                }
+                if(this.controller.hand.length) {
+                    choicemask = choicemask | 2;
+                }
+                switch(choicemask) {
+                    case 0://has no GR and no cards
+                        this.game.addMessage('{0} avoids {1}\'s punishment due to abject poverty', this.controller, this);
+                        break;
+                    case 1://only has GR
+                        this.payGR();
+                        break;
+                    case 2://only has cards
+                        this.havenRandomDiscard();
+                        break;
+                    case 3://has both GR and cards
+                        this.game.promptWithMenu(this.controller, this, {
+                            activePrompt: {
+                                menuTitle: 'Choose cheatin\' punishment',
+                                buttons: [
+                                    { text: 'Pay 1 GR', method: 'payGR' },
+                                    { text: 'Discard card', method: 'havenRandomDiscard' }
+                                ]
+                            },
+                            source: this
+                        });
+                        break;
+                    default://how did this happen?
+                        this.game.addMessage('Something went wrong when {0} triggered {1} (mask was {2})', this.controller, this, choicemask);
+                        break;
                 }
             }
         });
@@ -35,7 +54,7 @@ class HighStakesHaven extends DeedCard {
         this.controller.discardAtRandom(1, discarded => {
             this.game.addMessage('{0} discards randomly from hand card {1} due to {2}', 
                 this.controller, discarded, this);
-        });
+        }, false);
         return true;
     }
 }

--- a/server/game/cards/09.2-AGE/InnerStruggle.js
+++ b/server/game/cards/09.2-AGE/InnerStruggle.js
@@ -30,10 +30,14 @@ class InnerStruggle extends ActionCard {
                 const theirhome = context.player.getOpponent().getOutfitCard();
                 context.player.attach(this, theirhome, 'ability', () => {
                     this.booted = true;
-                    this.controller.discardAtRandom(1, discarded => {
-                        this.game.addMessage('{0} uses {1}, attaches it to {2} and {3} randomly discards {4}', 
-                            context.player, this, theirhome, this.controller, discarded);
-                    }, false);
+                    if(this.controller.hand.length) {
+                        this.controller.discardAtRandom(1, discarded => {
+                            this.game.addMessage('{0} uses {1}, attaches it to {2} and {3} randomly discards {4}', 
+                                context.player, this, theirhome, this.controller, discarded);
+                        }, false);
+                    } else {
+                        this.game.addMessage('{0} uses {1}, attaching it to {2}', context.player, this, theirhome);
+                    }
                 });
             }
         });

--- a/server/game/cards/10-BMR/GomorraGamingCommission.js
+++ b/server/game/cards/10-BMR/GomorraGamingCommission.js
@@ -27,7 +27,8 @@ class GomorraGamingCommission extends DeedCard {
                                 this.game.resolveGameAction(GameActions.drawCards({ player: context.player, amount: 1 }), context).thenExecute(() => {
                                     this.game.addMessage('{0} uses {1} to boost its production by 1 and draw a card', context.player, this);
                                 });
-                            }
+                            },
+                            source: this
                         });
                     } else {
                         this.game.resolveGameAction(GameActions.drawCards({ player: context.player, amount: 1 }), context).thenExecute(() => {

--- a/server/game/cards/16-DT2/QuickdrawHandgun2.js
+++ b/server/game/cards/16-DT2/QuickdrawHandgun2.js
@@ -17,9 +17,9 @@ class QuickdrawHandgun2 extends GoodsCard {
                 context.player.handResult = savedOppInfo.handResult;
                 opponent.drawHand = savedThisInfo.drawHand;
                 opponent.handResult = savedThisInfo.handResult;
-                opponent.getHandRank().cheatin = false;
                 context.player.determineHandResult('changes hand to');
                 opponent.determineHandResult('changes hand to');
+                context.player.getHandRank().cheatin = false;
                 this.game.addMessage('{0}\'s current rank: {1} (modifier {2})', 
                     context.player, context.player.getTotalRank(), context.player.rankModifier);
                 this.game.addMessage('{0}\'s current rank: {1} (modifier {2})', 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -330,8 +330,12 @@ class DrawCard extends BaseCard {
         if(!this.attachments) {
             return [];
         }
+        let searchKeywords = keywords;
+        if(!Array.isArray(keywords)) {
+            searchKeywords = [keywords];
+        }
         return this.attachments.filter(attachment => {
-            for(let keyword of keywords) {
+            for(let keyword of searchKeywords) {
                 if(!attachment.hasKeyword(keyword)) {
                     return false;
                 }
@@ -341,11 +345,7 @@ class DrawCard extends BaseCard {
     }
 
     hasAttachmentWithKeywords(keywords) {
-        let searchKeywords = keywords;
-        if(!Array.isArray(keywords)) {
-            searchKeywords = [keywords];
-        }
-        return this.getAttachmentsByKeywords(searchKeywords).length > 0;
+        return this.getAttachmentsByKeywords(keywords).length > 0;
     }
 
     removeAttachment(attachment) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -441,6 +441,10 @@ class Player extends Spectator {
         var toDiscard = Math.min(number, this.hand.length);
         var cards = [];
 
+        if(toDiscard <= 0) {
+            return false;
+        }
+
         while(cards.length < toDiscard) {
             var cardIndex = MathHelper.randomInt(this.hand.length);
 
@@ -456,6 +460,8 @@ class Player extends Spectator {
             }
             callback(discarded);
         });
+
+        return true;
     }
 
     resetCardPile(pile) {


### PR DESCRIPTION
* TheFlyingPopescus.js

Somehow isn't getting the infuence bonus. The hope is that arrayifying the getAttachmentsByKeyword input (to match every other use of that function) will fix this.

* HighStakesHaven.js

Having no cards in hand brought up the prompt where discard could be clicked, even when GR was available.
Total rework of handler.
Added false to discardAtRandom-call to prevent double-logging

* BackWays.js

PromptForLocation should return true; it was my mistake.
Location prompt stuck around and you could send the dude all over until finally clicking cancel.

* QuickdrawHandgun2.js

1) The user of the gun is the one who takes the illegal hand, and so the one who needs legalization.
2) As .determineHandResult() creates a new .handResult and subsequently a new .handRank, fiddling with the .handRank before calling .determineHandResult() is pointless.
The hand-changing message will still say the new hand is cheatin', but that now gets fixed before anything relevant can happen.

* RailroadStation.js

Prompt title includes target's name; destination must be different.

* GomorraGamingCommission.js

Finally adding source:this
Hopefully users will no longer be confused why there's suddenly a prompt

* InnerStruggle.js

Adding special message case for handless cheater.
There used to be no message in this case.

* Tusk

In case 2 Tusks were in play and opponent used a card ability, the prompt for trait order was displayed with 2 Tusk buttons.