### PR TITLE
Fix various bugs

### DIFF
--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -91,13 +91,29 @@ class BaseCardSelector {
         if(!card.allowGameAction('target', context)) {
             return false;
         }
-        if(typeof(this.gameAction) === 'function') {
+        return this.checkGameAction(card, context, this.gameAction);
+    }
+
+    checkGameAction(card, context, action) {
+        if(typeof(action) === 'function') {
             return card.allowGameAction(this.gameAction(card, context), context);
         }
-        if(!Array.isArray(this.gameAction)) {
-            return card.allowGameAction(this.gameAction, context);
+        if(action && (action.or || action.and)) {
+            let partial = false;
+            if(action.or) {
+                action.or = Array.isArray(action.or) ? action.or : [action.or];
+                partial = action.or.some(gameAction => this.checkGameAction(card, context, gameAction));
+            }
+            if(partial && action.and) {
+                action.and = Array.isArray(action.and) ? action.and : [action.and];
+                partial = action.and.every(gameAction => this.checkGameAction(card, context, gameAction));
+            }            
+            return partial;
+        }        
+        if(!Array.isArray(action)) {
+            return card.allowGameAction(action, context);
         }
-        return this.gameAction.every(gameAction => card.allowGameAction(gameAction, context));
+        return action.every(gameAction => card.allowGameAction(gameAction, context));
     }
 
     /**

--- a/server/game/GameActions/Search.js
+++ b/server/game/GameActions/Search.js
@@ -5,13 +5,14 @@ const Shuffle = require('./Shuffle');
 const Event = require('../event');
 
 class Search extends GameAction {
-    constructor({ gameAction, location, match, message, cancelMessage, topCards, numToSelect, 
+    constructor({ gameAction, location, match, message, cancelMessage, topCards, numToSelect, mode,
         doNotShuffleDeck, player, searchedPlayer, title, handler }) {
         super('search');
         this.gameAction = gameAction;
         this.match = match || {};
         this.topCards = topCards;
         this.numToSelect = numToSelect;
+        this.mode = mode;
         this.doNotShuffleDeck = doNotShuffleDeck;
         if(player) {
             this.playerFunc = (() => player);
@@ -40,7 +41,7 @@ class Search extends GameAction {
         return this.event('onDeckSearched', { player, searchedPlayer }, event => {
             const revealFunc = this.createRevealDrawDeckCards({ choosingPlayer: event.player, searchedPlayer: event.searchedPlayer, numCards: this.topCards });
             const searchCondition = this.createSearchCondition(event.searchedPlayer);
-            const modeProps = this.numToSelect ? { mode: 'upTo', numCards: this.numToSelect } : {};
+            const modeProps = this.numToSelect ? { mode: `${this.mode ? this.mode : 'upTo'}`, numCards: this.numToSelect } : {};
             if(this.location.includes('draw deck')) {
                 context.game.cardVisibility.addRule(revealFunc);
             }

--- a/server/game/cards/01-DTR/CharliesPlace.js
+++ b/server/game/cards/01-DTR/CharliesPlace.js
@@ -11,11 +11,10 @@ class CharliesPlace extends DeedCard {
                 cardCondition: { 
                     location: 'play area', 
                     controller: 'any', 
-                    condition: (card, context) => card.locationCard === this &&
-                        (card.allowGameAction('increaseBullets', context) || 
-                        card.allowGameAction('decreaseBullets', context))
+                    condition: (card) => card.locationCard === this
                 },
-                cardType: ['dude']
+                cardType: ['dude'],
+                gameAction: { or: ['increaseBullets', 'decreaseBullets'] }
             },
             handler: context => {
                 this.abilityContext = context;

--- a/server/game/cards/01-DTR/MorganResearchInstitute.js
+++ b/server/game/cards/01-DTR/MorganResearchInstitute.js
@@ -11,11 +11,10 @@ class MorganResearchInstitute extends DeedCard {
                 cardCondition: { 
                     location: 'play area', 
                     controller: 'any', 
-                    condition: card => card.locationCard === this && 
-                        card.isSkilled() &&
-                        (card.allowGameAction('increaseSkill') || card.allowGameAction('decreaseSkill'))
+                    condition: (card) => card.locationCard === this && card.isSkilled()
                 }, 
-                cardType: ['dude']
+                cardType: ['dude'],
+                gameAction: { or: ['increaseSkill', 'decreaseSkill'] }
             },
             handler: context => {
                 this.abilityContext = context;
@@ -48,13 +47,13 @@ class MorganResearchInstitute extends DeedCard {
                         text: 'Raise by 2', 
                         arg: skill, 
                         method: 'raise',
-                        disabled: !this.abilityContext.target.allowGameAction('increaseSkill')
+                        disabled: !this.abilityContext.target.allowGameAction('increaseSkill', this.abilityContext)
                     },
                     { 
                         text: 'Lower by 2', 
                         arg: skill, 
                         method: 'lower',
-                        disabled: !this.abilityContext.target.allowGameAction('decreaseSkill')
+                        disabled: !this.abilityContext.target.allowGameAction('decreaseSkill', this.abilityContext)
                     }
                 ]
             },

--- a/server/game/cards/02.3-EDS/TheMayorsOffice.js
+++ b/server/game/cards/02.3-EDS/TheMayorsOffice.js
@@ -7,9 +7,12 @@ class TheMayorsOffice extends DeedCard {
             playType: 'noon',
             cost: ability.costs.bootSelf(),
             target: {
-                cardCondition: {location: 'play area', condition: card => (card.gamelocation === this.gamelocation || card.isAdjacent(this.gamelocation))},
+                cardCondition: {
+                    location: 'play area', 
+                    condition: card => (card.gamelocation === this.gamelocation || card.isAdjacent(this.gamelocation))
+                },
                 cardType: 'dude',
-                gameAction: ['increaseInfluence', 'decreaseInfluence']
+                gameAction: { or: ['increaseInfluence', 'decreaseInfluence'] }
             },
             handler: context => {
                 this.abilityContext = context;
@@ -19,11 +22,13 @@ class TheMayorsOffice extends DeedCard {
                         buttons: [
                             {
                                 text: 'Raise by one',
-                                method: 'raise'
+                                method: 'raise',
+                                disabled: !this.abilityContext.target.allowGameAction('increaseInfluence', this.abilityContext)
                             },
                             {
                                 text: 'Lower by one',
-                                method: 'lower'
+                                method: 'lower',
+                                disabled: !this.abilityContext.target.allowGameAction('decreaseInfluence', this.abilityContext)
                             }
                         ]
                     },

--- a/server/game/cards/03-FF/FasterOnTheDraw.js
+++ b/server/game/cards/03-FF/FasterOnTheDraw.js
@@ -7,7 +7,7 @@ class FasterOnTheDraw extends ActionCard {
             playType: ['shootout'],
             target: {
                 activePromptTitle: 'Select your dude who will be faster on the draw',
-                cardCondition: { location: 'play area', participating: true },
+                cardCondition: { location: 'play area', controller: 'current', participating: true },
                 cardType: ['dude']
             },
             handler: context => {

--- a/server/game/cards/04.1-FJ/FuntimeFreddy.js
+++ b/server/game/cards/04.1-FJ/FuntimeFreddy.js
@@ -20,6 +20,7 @@ class FuntimeFreddy extends DudeCard {
                         },
                         location: ['draw deck'],
                         numToSelect: 2,
+                        mode: 'exact',
                         message: {
                             format: '{player} aces {source} to search their draw deck and let opponent choose between {searchTarget}'
                         },

--- a/server/game/cards/04.1-FJ/FuntimeFreddy.js
+++ b/server/game/cards/04.1-FJ/FuntimeFreddy.js
@@ -20,7 +20,7 @@ class FuntimeFreddy extends DudeCard {
                         },
                         location: ['draw deck'],
                         numToSelect: 2,
-                        mode: 'exact',
+                        mode: 'exactly',
                         message: {
                             format: '{player} aces {source} to search their draw deck and let opponent choose between {searchTarget}'
                         },

--- a/server/game/cards/07.1-DDeeds/DisgenuineCurrencyPress.js
+++ b/server/game/cards/07.1-DDeeds/DisgenuineCurrencyPress.js
@@ -14,6 +14,7 @@ class DisgenuineCurrencyPress extends GoodsCard {
             }
         });
         this.traitReaction({
+            triggerBefore: true,
             when: {
                 onCardDiscarded: event => event.card === this && event.originalLocation === 'play area'
             },

--- a/server/game/cards/08-GT/SilentSigil.js
+++ b/server/game/cards/08-GT/SilentSigil.js
@@ -1,4 +1,3 @@
-const PhaseNames = require('../../Constants/PhaseNames.js');
 const DeedCard = require('../../deedcard.js');
 
 class SilentSigil extends DeedCard {
@@ -11,7 +10,7 @@ class SilentSigil extends DeedCard {
         this.reaction({
             title: 'Silent Sigil',
             when: {
-                onCardsDrawn: event => event.reason === PhaseNames.Nightfall && event.player === this.controller
+                onAfterHandRefill: event => event.player.equals(this.controller)
             },
             message: context => this.game.addMessage('{0} uses {1} to draw an additional card', context.player, this),
             handler: context => {

--- a/server/game/cards/10-BMR/NickelNightInn.js
+++ b/server/game/cards/10-BMR/NickelNightInn.js
@@ -13,7 +13,7 @@ class NickelNightInn extends DeedCard {
                 location: 'play area',
                 cardCondition: {condition: card => (card.gamelocation === this.gamelocation || card.isAdjacent(this.gamelocation)) && card.value <= 3},
                 cardType: 'dude',
-                gameAction: 'bootDude'
+                gameAction: 'boot'
             },
             message: context => {
                 this.game.addMessage('{0} uses {1} to boot {2}', context.player, this, context.target);

--- a/server/game/cards/14-HCWM/FanninTheHammer.js
+++ b/server/game/cards/14-HCWM/FanninTheHammer.js
@@ -22,7 +22,6 @@ class FanninTheHammer extends ActionCard {
                             cardType: 'dude',
                             multiSelect: true,
                             numCards: context.target.bullets,
-                            mode: 'exactly',
                             onSelect: (player, cards) => {
                                 this.game.addMessage('{0} uses {1} and boots {2} to give {3} -1 bullets', 
                                     context.player, this, context.target, cards);

--- a/server/game/cards/15-W2D/DrJTGoodenough.js
+++ b/server/game/cards/15-W2D/DrJTGoodenough.js
@@ -21,7 +21,7 @@ class DrJTGoodenough extends DudeCard {
                         },
                         location: ['draw deck'],
                         numToSelect: 2,
-                        mode: 'exact',
+                        mode: 'exactly',
                         message: {
                             format: '{player} plays {source} to search their draw deck and let opponent choose between {searchTarget}'
                         },

--- a/server/game/cards/15-W2D/DrJTGoodenough.js
+++ b/server/game/cards/15-W2D/DrJTGoodenough.js
@@ -21,6 +21,7 @@ class DrJTGoodenough extends DudeCard {
                         },
                         location: ['draw deck'],
                         numToSelect: 2,
+                        mode: 'exact',
                         message: {
                             format: '{player} plays {source} to search their draw deck and let opponent choose between {searchTarget}'
                         },

--- a/server/game/cards/15-W2D/HeathsCuriosityShoppe.js
+++ b/server/game/cards/15-W2D/HeathsCuriosityShoppe.js
@@ -35,7 +35,7 @@ class HeathsCuriosityShoppe extends DeedCard {
                             },
                             source: this
                         }), context);
-                }, {}, context);
+                }, { discardExactly: true }, context);
             }
         });
     }

--- a/server/game/cards/16-DT2/BassReeves.js
+++ b/server/game/cards/16-DT2/BassReeves.js
@@ -34,7 +34,8 @@ class BassReeves extends DudeCard {
                     wanted: true,
                     condition: card => card.isNearby(this.gamelocation) 
                 },
-                cardType: ['dude']
+                cardType: ['dude'],
+                gameAction: { or: ['boot', 'callout'] }
             },
             ifCondition: () => !this.booted,
             ifFailMessage: context => 
@@ -49,12 +50,12 @@ class BassReeves extends DudeCard {
                             { 
                                 text: 'Boot', 
                                 method: 'bassBoot',
-                                disabled: !this.abilityContext.target.allowGameAction('boot')
+                                disabled: !this.abilityContext.target.allowGameAction('boot', this.abilityContext)
                             },
                             { 
                                 text: 'Call Out', 
                                 method: 'bassCallout',
-                                disabled: !this.abilityContext.target.allowGameAction('callout')
+                                disabled: !this.abilityContext.target.allowGameAction('callout', this.abilityContext)
                             }
                         ]
                     },

--- a/server/game/cards/16-DT2/LauraBanks.js
+++ b/server/game/cards/16-DT2/LauraBanks.js
@@ -11,7 +11,8 @@ class LauraBanks extends DudeCard {
             target: {
                 activePromptTitle: 'Choose a dude',
                 cardCondition: { location: 'play area', controller: 'any', participating: true },
-                cardType: ['dude']
+                cardType: ['dude'],
+                gameAction: { or: ['addBounty', 'removeBounty'] }
             },
             handler: context => {
                 this.abilityContext = context;
@@ -23,13 +24,13 @@ class LauraBanks extends DudeCard {
                                 text: 'Increase by 1', 
                                 method: 'changeBountyLaura',
                                 arg: 'increase',
-                                disabled: !this.abilityContext.target.allowGameAction('addBounty')
+                                disabled: !this.abilityContext.target.allowGameAction('addBounty', this.abilityContext)
                             },
                             { 
                                 text: 'Decrease by 1', 
                                 method: 'changeBountyLaura',
                                 arg: 'decrease',
-                                disabled: !this.abilityContext.target.allowGameAction('removeBounty') &&
+                                disabled: !this.abilityContext.target.allowGameAction('removeBounty', this.abilityContext) &&
                                     context.target.bounty > 0
                             }
                         ]

--- a/server/game/cards/16-DT2/ThirstForBlood.js
+++ b/server/game/cards/16-DT2/ThirstForBlood.js
@@ -15,7 +15,8 @@ class ThirstForBlood extends ActionCard {
                     participating: true,
                     condition: card => card.influence > 0
                 },
-                cardType: ['dude']
+                cardType: ['dude'],
+                gameAction: { or: ['setAsStud', 'increaseBullets', 'addBounty'] }
             },
             handler: context => {
                 this.abilityContext = context;
@@ -27,19 +28,19 @@ class ThirstForBlood extends ActionCard {
                                 text: 'Make them a stud', 
                                 method: 'applyTfBEffects',
                                 arg: 'makeStud',
-                                disabled: !this.abilityContext.target.allowGameAction('setAsStud')
+                                disabled: !this.abilityContext.target.allowGameAction('setAsStud', this.abilityContext)
                             },
                             { 
                                 text: 'Give them +2 bullets', 
                                 method: 'applyTfBEffects',
                                 arg: 'giveBullets',
-                                disabled: !this.abilityContext.target.allowGameAction('increaseBullets')
+                                disabled: !this.abilityContext.target.allowGameAction('increaseBullets', this.abilityContext)
                             },
                             { 
                                 text: 'Increase bounty to gain both', 
                                 method: 'applyTfBEffects',
                                 arg: 'gainBoth',
-                                disabled: !this.abilityContext.target.allowGameAction('addBounty')
+                                disabled: !this.abilityContext.target.allowGameAction('addBounty', this.abilityContext)
                             }
                         ]
                     },


### PR DESCRIPTION
Fixes some stuff from the #1467 
- [Disgenuine Currency Press](https://dtdb.co/en/card/11016)
- [Heath's Curiosity Shoppe](https://dtdb.co/en/card/23031)
- [Funtime Freddy](https://dtdb.co/en/card/06001) - by adding a `mode` to the `Search game action, which can be then set to 'exact'.
- [Fannin' the Hammer](https://dtdb.co/en/card/22051)
- [Nickel Night Inn](https://dtdb.co/en/card/18022)
- [Faster on the Draw](https://dtdb.co/en/card/05037)
- [Silent Sigil](https://dtdb.co/en/card/14021) - setting the event to `onAfterHandRefill` instead of card draw event.
- [The Mayor's Office](https://dtdb.co/en/card/04012) - added game action checks to buttons, but also improved how the game action validation against the target are done. Since it was improved, also other cards were updated.