### PR TITLE
Update DrawCards action in case not enough in deck

### DIFF
--- a/server/game/GameActions/DrawCards.js
+++ b/server/game/GameActions/DrawCards.js
@@ -31,19 +31,8 @@ class DrawCards extends GameAction {
         };
 
         return this.event('onCardsDrawn', eventProps, event => {
-            event.cards = event.player.drawDeckAction(event.amount, card => {
-                event.thenAttachEvent(
-                    this.event('onCardDrawn', { 
-                        card, 
-                        player: event.player, 
-                        reason: event.reason, 
-                        source: event.source, 
-                        target: event.target 
-                    }, () => {
-                        player.placeCardInPile({ card, location: event.target });
-                    })
-                );                
-            });
+            event.cards = event.player.drawDeckAction(event.amount, card => 
+                player.placeCardInPile({ card, location: event.target }));
         });
     }
 }


### PR DESCRIPTION
Attempt to fix situation when cards are not drawn into draw deck when there is not enough cards in deck and discard has to be shuffled into the draw deck.
It is working locally because I suspect it is a racing thing when the event of placing the cards into the draw deck is done before the shuffling is done. 