### PR TITLE
Add equals to test player

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -141,6 +141,7 @@ class Player extends Spectator {
                 name: 'test player', 
                 isCheatin: () => false, 
                 modifyGhostRock: () => true,
+                equals: player => player.name === 'test player',
                 cardsInPlay: [], 
                 drawDeck: [],
                 hand: [],


### PR DESCRIPTION
Fixes latest error reported by sentry: `player.equals is not a function`