### PR TITLE
Implement Effects in UI

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -6,15 +6,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  call-bump-version:
-    uses: townteki/townsquare/.github/workflows/bump-version.yml@development
-    secrets: inherit
-    with:
-      branch: development
   deploy-dev:
     runs-on: ubuntu-latest
-    needs: call-bump-version
     steps:
+      - uses: actions/checkout@v2
+      - name: Update version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "module.exports = {" > version.js
+          dateNow=$(date +"%Y-%m-%d")
+          echo "    releaseDate:'${dateNow}'," >> version.js
+          echo "    build:'${VERSION}-dev'" >> version.js
+          echo "}" >> version.js  
       - name: Trigger deploy workflow in townsquare-client
         uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:

--- a/server/game/Message.js
+++ b/server/game/Message.js
@@ -43,7 +43,7 @@ class Message {
         if(Array.isArray(arg)) {
             return this.formatArray(arg);
         } else if(arg instanceof BaseCard) {
-            return { code: arg.code, label: arg.title, type: arg.getType(), argType: 'card' };
+            return { code: arg.code, title: arg.title, type: arg.getType(), argType: 'card', uuid: arg.uuid };
         } else if(arg instanceof Spectator) {
             return { name: arg.user.username, argType: 'nonAvatarPlayer' };
         } else if(arg instanceof Message) {

--- a/server/game/PlainTextGameChatFormatter.js
+++ b/server/game/PlainTextGameChatFormatter.js
@@ -48,7 +48,7 @@ class PlainTextGameChatFormatter {
             } else if(fragment.message) {
                 result += this.formatMessageFragment(fragment.message);
             } else if(fragment.argType === 'card') {
-                result += fragment.label;
+                result += fragment.title;
             } else if(fragment.name && fragment.argType === 'player') {
                 result += `${fragment.name}:`;
             } else if(fragment.argType === 'nonAvatarPlayer') {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -619,7 +619,7 @@ class BaseCard extends NullCard {
         }
         let menuCardActionItems = menuActionItems.filter(menuItem => menuItem.action.abilitySourceType === 'card');
         if(menuCardActionItems.length > 0) {
-            let menuIcon = 'flash';
+            let menuIcon = 'cog';
             const disabled = menuCardActionItems.every(menuItem => menuItem.item.disabled);
             if(disabled) {
                 if(menuCardActionItems.length === 1) {
@@ -1156,7 +1156,8 @@ class BaseCard extends NullCard {
             }
             return facedownSummary;
         }
-        const effects = this.game.effectEngine.getAppliedEffectsOnCard(this).map(effect => effect.getSummary());
+        const effects = this.game.effectEngine.getAppliedEffectsOnTarget(this)
+            .filter(effect => effect.effect.title).map(effect => effect.getSummary());
 
         let state = {
             printedStats: {
@@ -1171,6 +1172,7 @@ class BaseCard extends NullCard {
                 production: this.cardData.production
             },
             bullets: this.bullets,
+            classType: 'card',
             code: this.cardData.code,
             cost: this.cardData.cost,
             controlled: this.owner !== this.controller,

--- a/server/game/cards/01-DTR/Rumors.js
+++ b/server/game/cards/01-DTR/Rumors.js
@@ -17,7 +17,7 @@ class Rumors extends ActionCard {
                 this.applyAbilityEffect(context.ability, ability => ({
                     condition: () => 
                         !this.game.isHome(context.target.gamelocation, context.target.controller),
-                    match: context.target,
+                    match: card => card.equals(context.target),
                     effect: ability.effects.modifyInfluence(-1)
                 }));
             }

--- a/server/game/cards/04.3-NN/SwordOfTheSpirit.js
+++ b/server/game/cards/04.3-NN/SwordOfTheSpirit.js
@@ -26,7 +26,7 @@ class SwordOfTheSpirit extends SpellCard {
                             onSelect: (player, weapon) => {
                                 this.applyAbilityEffect(context.ability, ability => ({
                                     condition: () => !!weapon.parent && weapon.parent === dudeWithWeapon,
-                                    match: dudeWithWeapon,
+                                    match: card => card.equals(dudeWithWeapon),
                                     effect: [
                                         ability.effects.modifyBullets(1),
                                         ability.effects.setAsStud(),

--- a/server/game/cards/07.3-BadM/TheOrphanage.js
+++ b/server/game/cards/07.3-BadM/TheOrphanage.js
@@ -26,7 +26,7 @@ class TheOrphanage extends DeedCard {
     }
 
     getDeedControlWoOrphanage(card) {
-        const effects = this.game.effectEngine.getAppliedEffectsOnCard(card);
+        const effects = this.game.effectEngine.getAppliedEffectsOnTarget(card);
         if(effects && effects.some(effect => this.equals(effect.source))) {
             return card.control + 1;
         }

--- a/server/game/cards/09.1-TCR/CominUpRoses.js
+++ b/server/game/cards/09.1-TCR/CominUpRoses.js
@@ -72,7 +72,7 @@ class CominUpRoses extends ActionCard {
             if(this.cheatinResContext) {
                 this.applyAbilityEffect(this.cheatinResContext.ability, ability => ({
                     condition: () => [5, 6, 9].includes(player.getHandRank().rank) && !player.isCheatin(),
-                    match: () => player,
+                    match: matchPlayer => matchPlayer.equals(player),
                     effect: ability.effects.modifyHandRankMod(2)
                 }));
                 this.game.addMessage('{0}\'s new hand rank is {2}', player, this, player.getTotalRank());

--- a/server/game/cards/13-O4B/Malison.js
+++ b/server/game/cards/13-O4B/Malison.js
@@ -20,14 +20,14 @@ class Malison extends SpellCard {
                 if(context.target.isStud()) {
                     this.applyAbilityEffect(context.ability, ability => ({
                         condition: () => context.target.isParticipating(),
-                        match: this.controller,
+                        match: player => player.equals(this.controller),
                         effect: ability.effects.modifyPosseStudBonus(1)
                     }));
                     this.game.addMessage('{0} uses {1} to give their posse +1 stud bonus', context.player, this);
                 } else {
                     this.applyAbilityEffect(context.ability, ability => ({
                         condition: () => context.target.isParticipating(),
-                        match: this.controller,
+                        match: player => player.equals(this.controller),
                         effect: ability.effects.modifyPosseDrawBonus(1)
                     }));
                     this.game.addMessage('{0} uses {1} to give their posse +1 draw bonus', context.player, this);            

--- a/server/game/cards/13-O4B/Scattergun.js
+++ b/server/game/cards/13-O4B/Scattergun.js
@@ -49,7 +49,7 @@ class Scattergun extends GoodsCard {
             handler: context => {
                 this.applyAbilityEffect(context.ability, ability => ({
                     condition: () => !this.isDudeAShooter(context.target),
-                    match: context.target,
+                    match: card => card.equals(context.target),
                     effect: ability.effects.doesNotProvideBulletRatings()
                 }));
             }

--- a/server/game/cards/13-O4B/TwilightIsUponUs.js
+++ b/server/game/cards/13-O4B/TwilightIsUponUs.js
@@ -29,20 +29,24 @@ class TwilightIsUponUs extends ActionCard {
                         this.game.addMessage('{0} uses {1} to join {2} to posse', context.player, this, context.target);
                     });
                 }
-                const eventHandler = event => {
-                    const thisPosse = this.game.shootout.getPosseByPlayer(event.player);
-                    if(thisPosse.getDudes(dude => dude.isSkilled()).length) {
-                        this.applyAbilityEffect(context.ability, ability => ({
-                            match: event.card,
-                            effect: ability.effects.modifyBullets(2)
-                        }));
-                    }
-                };
-                this.game.on('onShooterPicked', eventHandler);
-                this.game.once('onShootoutPhaseFinished', () => this.game.removeListener('onShooterPicked', eventHandler));                
-                this.game.once('onShootoutRoundFinished', () => this.game.removeListener('onShooterPicked', eventHandler));
+                this.untilEndOfShootoutPhase(context.ability, ability => ({
+                    condition: () => this.game.shootout,
+                    match: player => this.isSkilledDudeInPosse(player),
+                    effect: ability.effects.modifyPosseShooterBonus(2)
+                }));
             }
         });
+    }
+
+    isSkilledDudeInPosse(player) {
+        if(!this.game.shootout) {
+            return false;
+        }
+        const playerPosse = this.game.shootout.getPosseByPlayer(player);
+        if(!playerPosse) {
+            return false;
+        }
+        return !!playerPosse.findInPosse(dude => dude.isSkilled());
     }
 }
 

--- a/server/game/cards/15-W2D/LewisGrizzlyEvans.js
+++ b/server/game/cards/15-W2D/LewisGrizzlyEvans.js
@@ -38,13 +38,13 @@ class LewisGrizzlyEvans extends DudeCard {
                     this.applyAbilityEffect(context.ability, ability => ({
                         condition: () => this.game.shootout && 
                             this.game.shootout.getPosseSize(context.player) > 1,
-                        match: this,
+                        match: card => card.equals(this),
                         effect: ability.effects.doesNotProvideBulletRatings()
                     }));
                     this.applyAbilityEffect(context.ability, ability => ({
                         condition: () => this.game.shootout && 
                             this.game.shootout.getPosseSize(context.target.controller) > 1,
-                        match: context.target,
+                        match: card => card.equals(context.target),
                         effect: ability.effects.doesNotProvideBulletRatings()
                     }));                    
                 }

--- a/server/game/cards/16-DT2/FireOfNanahbozho2.js
+++ b/server/game/cards/16-DT2/FireOfNanahbozho2.js
@@ -44,7 +44,7 @@ class FireOfNanahbozho2 extends SpellCard {
     }
 
     isAffectedByFire(card) {
-        const effects = this.game.effectEngine.getAppliedEffectsOnCard(card);
+        const effects = this.game.effectEngine.getAppliedEffectsOnTarget(card);
         return effects && effects.some(effect => effect.source && ['25257', '10033'].includes(effect.source.code));
     }
 }

--- a/server/game/cards/16-DT2/SwordOfTheSpirit2.js
+++ b/server/game/cards/16-DT2/SwordOfTheSpirit2.js
@@ -20,7 +20,7 @@ class SwordOfTheSpirit2 extends SpellCard {
                         }));  
                         this.applyAbilityEffect(context.ability, ability => ({
                             condition: () => dudeWithWeapon.hasAttachmentWithKeywords(['melee', 'weapon']),
-                            match: dudeWithWeapon,
+                            match: card => card.equals(dudeWithWeapon),
                             effect: [
                                 ability.effects.setAsStud(),
                                 ability.effects.cannotBeAffected('opponent', context => context.source && context.source.getType() === 'spell')

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -265,7 +265,7 @@ class DrawCard extends BaseCard {
             targetController: 'any',
             effect: properties.effect,
             recalculateWhen: properties.recalculateWhen,
-            fromTrait: properties.fromTrait
+            fromTrait: properties.fromTrait === undefined ? true : properties.fromTrait
         });
     }
 

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -4,11 +4,14 @@ const {flatten} = require('../Array');
  * Represents a card based effect applied to one or more targets.
  *
  * Properties:
- * match            - function that takes a card and context object and returns
+ * match            - function that takes a card or player and context object and returns
  *                    a boolean about whether the passed card should have the
  *                    effect applied. Alternatively, a card can be passed as the
  *                    match property to match that single card, or an array of
  *                    cards to match each of them.
+ *                    WARNING: match has to be a function in case duration is not 'persistent'
+ *                             and effect is conditional if you want targets to be dynamically
+ *                             updated.
  * duration         - string representing how long the effect lasts.
  * until            - optional object to specify events that will cancel the
  *                    effect when duration is 'custom'. The keys of the object
@@ -326,9 +329,11 @@ class Effect {
 
     getSummary() {
         return {
-            title: this.effect.title,
+            duration: this.duration,
+            fromTrait: this.fromTrait,
             gameAction: this.effect.gameAction,
-            source: this.source.uuid
+            source: this.source.uuid,
+            title: this.effect.title
         };
     }
 }

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -226,8 +226,8 @@ class EffectEngine {
         return this.effects.filter(effect => effect.hasTarget(card) && predicate(effect));
     }
 
-    getAppliedEffectsOnCard(card, predicate = () => true) {
-        return this.effects.filter(effect => effect.isAppliedTo(card) && predicate(effect));
+    getAppliedEffectsOnTarget(target, predicate = () => true) {
+        return this.effects.filter(effect => effect.isAppliedTo(target) && predicate(effect));
     }
 }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -104,19 +104,6 @@ function shootoutRestrictionEffect(restrictions, title) {
     }; 
 }
 
-function losesAspectEffect(aspect) {
-    return function() {
-        return {
-            apply: function(card) {
-                card.loseAspect(aspect);
-            },
-            unapply: function(card) {
-                card.restoreAspect(aspect);
-            }
-        };
-    };
-}
-
 function optionEffect(key, title) {
     return function(source, condition) {
         return {
@@ -149,6 +136,8 @@ function playerOptionEffect(key, title) {
 function adjacency(type) {
     return function(location, source) {
         return {
+            title: type === 'adjacent' ? `Added adjacency to ${location.title}` :
+                `Prevented adjacency to ${location.title}`,
             apply: function(card) {
                 if(card.isLocationCard()) {
                     card.addAdjacencyLocation(location, source, type);
@@ -164,6 +153,7 @@ function adjacency(type) {
 function conditionalAdjacency(type) {
     return function (condition, source) {
         return {
+            title: type === 'adjacent' ? 'Added conditional adjacency' : 'Prevented conditional adjacency',
             apply: function(card, context) {
                 if(!card.isLocationCard()) {
                     return;
@@ -206,7 +196,7 @@ function dynamicStatModifier(propName) {
                 context[dynamicPropName] = context[dynamicPropName] || {};
                 context[dynamicPropName][card.uuid] = calculate(card, context) || 0;
                 let value = context[dynamicPropName][card.uuid];
-                this.title = `${propNameCapital} modified: ${value}`;
+                this.title = `${propNameCapital} dynamically modified: ${value > 0 ? '+' : ''}${value}`;
                 card[functionName](value, true, true);
             },
             reapply: function(card, context) {
@@ -214,10 +204,12 @@ function dynamicStatModifier(propName) {
                 let newProperty = calculate(card, context) || 0;
                 context[dynamicPropName][card.uuid] = newProperty;
                 let value = newProperty - currentProperty;
+                this.title = `${propNameCapital} dynamically modified: ${value > 0 ? '+' : ''}${value}`;
                 card[functionName](value, true, true);
             },
             unapply: function(card, context) {
                 let value = context[dynamicPropName][card.uuid];
+                this.title = `${propNameCapital} dynamically modified`;
                 card[functionName](-value, false, true);
                 delete context[dynamicPropName][card.uuid];
             },
@@ -229,7 +221,7 @@ function dynamicStatModifier(propName) {
 const Effects = {
     setAsStud: function() {
         return {
-            title: 'Stud bullet modifier',
+            title: 'Make Dude a Stud',
             gameAction: 'setAsStud',
             apply: function(card, context) {
                 if(card.getType() === 'dude') {
@@ -248,7 +240,7 @@ const Effects = {
     },
     setAsDraw: function() {
         return {
-            title: 'Draw bullet modifier',
+            title: 'Make Dude a Draw',
             gameAction: 'setAsDraw',
             apply: function(card, context) {
                 if(card.getType() === 'dude') {
@@ -267,7 +259,7 @@ const Effects = {
     },
     setMaxBullets: function(value) {
         return {
-            title: `Set Max Bullets to ${value}`,
+            title: `Set max Bullets to ${value}`,
             apply: function(card, context) {
                 context.setMaxBullets = context.setMaxBullets || {};
                 context.setMaxBullets[card.uuid] = card.maxBullets;
@@ -281,7 +273,7 @@ const Effects = {
     },
     setMinBullets: function(value) {
         return {
-            title: `Set Min Bullets to ${value}`,
+            title: `Set min Bullets to ${value}`,
             apply: function(card, context) {
                 context.setMinBullets = context.setMinBullets || {};
                 context.setMinBullets[card.uuid] = card.minBullets;
@@ -307,7 +299,7 @@ const Effects = {
     },
     setMaxInfByLocation: function(value) {
         return {
-            title: `Set Max Inf in Location to ${value}`,
+            title: `Set max Influence in location to ${value}`,
             targetType: 'player',
             apply: function(player, context) {
                 context.setMaxInfByLocation = context.setMaxInfByLocation || {};
@@ -322,7 +314,7 @@ const Effects = {
     },
     determineControlByBullets: function() {
         return {
-            title: 'Control Determinator: Bullets',
+            title: 'Determine control by Bullets',
             apply: function(card, context) {
                 context.controlDeterminator = context.controlDeterminator || {};
                 context.controlDeterminator[card.uuid] = card.controlDeterminator;
@@ -336,7 +328,7 @@ const Effects = {
     }, 
     determineControlBySkill: function(skillName) {
         return {
-            title: `Control Determinator: Skill - ${skillName}`,
+            title: `Determine control by Skill - ${skillName}`,
             apply: function(card, context) {
                 context.controlDeterminator = context.controlDeterminator || {};
                 context.controlDeterminator[card.uuid] = card.controlDeterminator;
@@ -385,7 +377,7 @@ const Effects = {
     },
     modifyBullets: function(value) {
         return {
-            title: `Bullets modified: ${value}`,
+            title: `Bullets modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseBullets' : 'increaseBullets',
             apply: function(card) {
                 card.modifyBullets(value, true, true);
@@ -412,7 +404,7 @@ const Effects = {
     },
     modifyInfluence: function(value) {
         return {
-            title: `Influence modified: ${value}`,
+            title: `Influence modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseInfluence' : 'increaseInfluence',
             apply: function(card) {
                 card.modifyInfluence(value, true, true);
@@ -439,7 +431,7 @@ const Effects = {
     },
     modifyDeedInfluence: function(value) {
         return {
-            title: `Deed Influence modified: ${value}`,
+            title: `Influence for Deed control modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseInfluence' : 'increaseInfluence',
             apply: function(card) {
                 card.modifyDeedInfluence(value, true);
@@ -451,7 +443,7 @@ const Effects = {
     },
     modifyControl: function(value) {
         return {
-            title: `Control modified: ${value}`,
+            title: `Control modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseControl' : 'increaseControl',
             apply: function(card) {
                 card.modifyControl(value, true, true);
@@ -478,7 +470,7 @@ const Effects = {
     },
     modifyValue: function(value) {
         return {
-            title: `Value modified: ${value}`,
+            title: `Value modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseValue' : 'increaseValue',
             apply: function(card) {
                 card.modifyValue(value, true, true);
@@ -505,7 +497,7 @@ const Effects = {
     },
     modifyProduction: function(value) {
         return {
-            title: `Production modified: ${value}`,
+            title: `Production modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseProduction' : 'increaseProduction',
             apply: function(card) {
                 card.modifyProduction(value, true, true);
@@ -534,7 +526,7 @@ const Effects = {
 
     modifyUpkeep: function(value) {
         return {
-            title: `Upkeep modified: ${value}`,
+            title: `Upkeep modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseUpkeep' : 'increaseUpkeep',
             apply: function(card) {
                 card.modifyUpkeep(value, true, true);
@@ -546,7 +538,7 @@ const Effects = {
     },
     modifySkillRating: function(type, value) {
         return {
-            title: `Skill Rating modified: ${value}`,
+            title: `Skill Rating modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseSkill' + type : 'increaseSkill' + type,
             apply: function(card) {
                 if(type === 'anySkill') {
@@ -577,6 +569,7 @@ const Effects = {
                 context.dynamicSkillRating = context.dynamicSkillRating || {};
                 context.dynamicSkillRating[card.uuid] = skillRatingFunc(card, context) || 0;
                 let value = context.dynamicSkillRating[card.uuid];
+                this.title = `${type[0].toUpperCase() + type.slice(1)} rating dynamically modified: ${value > 0 ? '+' : ''}${value}`;
                 card.modifySkillRating(type, value);
             },
             reapply: function(card, context) {
@@ -584,11 +577,13 @@ const Effects = {
                 let newProperty = skillRatingFunc(card, context) || 0;
                 context.dynamicSkillRating[card.uuid] = newProperty;
                 let value = newProperty - currentProperty;
+                this.title = `${type[0].toUpperCase() + type.slice(1)} rating dynamically modified: ${value > 0 ? '+' : ''}${value}`;
                 card.modifySkillRating(type, value);
             },
             unapply: function(card, context) {
                 let value = context.dynamicSkillRating[card.uuid];
                 card.modifySkillRating(type, -value, false);
+                this.title = `${type[0].toUpperCase() + type.slice(1)} rating dynamically modified`;
                 delete context.dynamicSkillRating[card.uuid];
             },
             isStateDependent: true
@@ -596,7 +591,7 @@ const Effects = {
     },
     modifyDifficulty: function(value) {
         return {
-            title: `Difficulty modified: ${value}`,
+            title: `Difficulty modified: ${value > 0 ? '+' : ''}${value}`,
             gameAction: value < 0 ? 'decreaseDifficulty' : 'increaseDifficulty',
             apply: function(card) {
                 card.difficultyMod += value;
@@ -608,7 +603,7 @@ const Effects = {
     },    
     modifyPlayerControl: function(value) {
         return {
-            title: `Player Control modified: ${value}`,
+            title: `Player Control modified: ${value > 0 ? '+' : ''}${value}`,
             apply: function(player) {
                 player.control += value;
             },
@@ -644,7 +639,7 @@ const Effects = {
     dynamicUpkeep: dynamicStatModifier('upkeep'),
     modifyHandSize: function(value) {
         return {
-            title: `Hand Size modified: ${value}`,
+            title: `Hand Size modified: ${value > 0 ? '+' : ''}${value}`,
             targetType: 'player',
             apply: function(player) {
                 player.handSize += value;
@@ -656,7 +651,7 @@ const Effects = {
     },
     modifyNightfallDiscard: function(value) {
         return {
-            title: `Nightfall Discard modified: ${value}`,
+            title: `Nightfall Discard modified: ${value > 0 ? '+' : ''}${value}`,
             targetType: 'player',
             apply: function(player) {
                 player.discardNumber += value;
@@ -668,7 +663,7 @@ const Effects = {
     },
     modifyHandRankMod: function(value) {
         return {
-            title: `Hand Rank modified: ${value}`,
+            title: `Hand Rank modified: ${value > 0 ? '+' : ''}${value}`,
             targetType: 'player',
             gameAction: 'modifyHandRank',
             apply: function(player, context) {
@@ -691,7 +686,7 @@ const Effects = {
                 context.dynamicHandRank = context.dynamicHandRank || {};
                 context.dynamicHandRank[player.name] = calculate(player, context) || 0;
                 let value = context.dynamicHandRank[player.name];
-                this.title = `Hand Rank modified: ${value}`;
+                this.title = `Hand Rank dynamically modified: ${value > 0 ? '+' : ''}${value}`;
                 player.modifyRank(value, context, true, true);
             },
             reapply: function(player, context) {
@@ -699,10 +694,12 @@ const Effects = {
                 let newProperty = calculate(player, context) || 0;
                 context.dynamicHandRank[player.name] = newProperty;
                 let value = newProperty - currentProperty;
+                this.title = `Hand Rank dynamically modified: ${value > 0 ? '+' : ''}${value}`;
                 player.modifyRank(value, context, true, true);
             },
             unapply: function(player, context) {
                 let value = context.dynamicHandRank[player.name];
+                this.title = 'Hand Rank dynamically modified';
                 player.modifyRank(-value, context, false, true);
                 delete context.dynamicHandRank[player.name];
             },
@@ -773,7 +770,6 @@ const Effects = {
             }
         };
     },
-    losesAllKeywords: losesAspectEffect('keywords'),
     addCardAction: function(properties) {
         return {
             title: `Card Action added: ${properties.title}`,
@@ -793,7 +789,7 @@ const Effects = {
     },
     addSkillKfBonus: function(bonus, source) {
         return {
-            title: 'Skill or KF bonus added',
+            title: 'Skill or Kung Fu bonus added',
             apply: function(card) {
                 if(card.getType() === 'dude') {
                     card.addSkillKfBonus(bonus, source);
@@ -1020,7 +1016,7 @@ const Effects = {
         playerOptionEffect('discardAllDuringNightfall', 'Discard all cards during Nightfall'),        
     modifyPosseStudBonus: function(amount) {
         return {
-            title: `Stud Bonus modified: ${amount}`,
+            title: `Stud Bonus modified: ${amount > 0 ? '+' : ''}${amount}`,
             targetType: 'player',
             apply: function(player) {
                 player.modifyPosseBonus(amount, 'stud');
@@ -1032,7 +1028,7 @@ const Effects = {
     },
     modifyPosseDrawBonus: function(amount) {
         return {
-            title: `Draw Bonus modified: ${amount}`,
+            title: `Draw Bonus modified: ${amount > 0 ? '+' : ''}${amount}`,
             targetType: 'player',
             apply: function(player) {
                 player.modifyPosseBonus(amount, 'draw');
@@ -1044,7 +1040,7 @@ const Effects = {
     },
     modifyPosseShooterBonus: function(amount) {
         return {
-            title: `Shooter Bonus modified: ${amount}`,
+            title: `Shooter Bonus modified: ${amount > 0 ? '+' : ''}${amount}`,
             targetType: 'player',
             apply: function(player) {
                 player.modifyPosseShooterBonus(amount);
@@ -1056,7 +1052,7 @@ const Effects = {
     },
     addRedrawBonus: function(amount) {
         return {
-            title: `Redraw Bonus modified: ${amount}`,
+            title: `Redraw Bonus modified: ${amount > 0 ? '+' : ''}${amount}`,
             targetType: 'player',
             apply: function(player) {
                 player.redrawBonus += amount;
@@ -1068,7 +1064,7 @@ const Effects = {
     },
     modifyLoserCasualties: function(amount) {
         return {
-            title: `Loser Casualties modified: ${amount}`,
+            title: `Loser Casualties modified: ${amount > 0 ? '+' : ''}${amount}`,
             targetType: 'shootout',
             apply: function(shootout) {
                 shootout.loserCasualtiesMod += amount;
@@ -1192,6 +1188,7 @@ const Effects = {
     changeWeaponLimitFunction: function(weaponLimitFunc) {
         var savedFunc;
         return {
+            title: 'Changes Weapon Limit',
             apply: function(card) {
                 savedFunc = card.checkWeaponLimit;
                 card.checkWeaponLimit = () => {
@@ -1205,6 +1202,7 @@ const Effects = {
     },
     setGritFunc: function(func) {
         return {
+            title: 'Changes Grit',
             apply: function(card, context) {
                 context.setGritFunc = context.setGritFunc || {};
                 context.setGritFunc[card.uuid] = card.gritFunc;
@@ -1219,6 +1217,7 @@ const Effects = {
     reduceCost: function(properties) {
         return {
             targetType: 'player',
+            title: `${properties.isIncrease ? 'Increase' : 'Reduce'} cost by ${properties.amount}`,
             apply: function(player, context) {
                 context.reducers = context.reducers || [];
                 var reducer = new CostReducer(context.game, context.source, properties);

--- a/server/game/gamesteps/shootout.js
+++ b/server/game/gamesteps/shootout.js
@@ -574,12 +574,14 @@ class Shootout extends Phase {
                 casualties: player.casualties
             };
         });
+        const effects = this.game.effectEngine.getAppliedEffectsOnTarget(this)
+            .filter(effect => effect.effect && effect.effect.title).map(effect => effect.getSummary());
 
         return {
-            effects: null,
+            classType: 'shootout',
+            effects: effects,
             round: this.round,
             playerStats
-
         };
     }
 }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1992,9 +1992,10 @@ class Player extends Spectator {
                 order: location.order
             };
         });
+        const effects = this.game.effectEngine.getAppliedEffectsOnTarget(this)
+            .filter(effect => effect.effect && effect.effect.title).map(effect => effect.getSummary());
 
         let state = {
-            legend: this.legend ? this.legend.getSummary(activePlayer) : null,
             cardPiles: {
                 cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
                 deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
@@ -2004,11 +2005,14 @@ class Player extends Spectator {
                 drawHand: this.getSummaryForCardList(this.drawHand, activePlayer),
                 beingPlayed: this.getSummaryForCardList(this.beingPlayed, activePlayer)
             },
+            classType: 'player',
+            effects: effects,
             inCheck: this.currentCheck,
             disconnected: !!this.disconnectedAt,
             outfit: this.outfit.getSummary(activePlayer),
             firstPlayer: this.firstPlayer,
             handRank: this.handResult.rank,
+            legend: this.legend ? this.legend.getSummary(activePlayer) : null,
             locations: locationsState,
             id: this.id,
             left: this.left,

--- a/test/server/Message.spec.js
+++ b/test/server/Message.spec.js
@@ -120,6 +120,7 @@ describe('Message', function() {
                         title: 'Funslinger Emtwo',
                         type_code: 'dude'
                     });
+                    this.cardUuid = card.uuid;
                     this.message = new Message({
                         format: 'Player 1 plays {card}',
                         args: { card }
@@ -127,7 +128,7 @@ describe('Message', function() {
                 });
 
                 it('converts the card argument', function() {
-                    expect(this.message.flatten()).toEqual(['Player 1 plays ', { argType: 'card', code: '12345', label: 'Funslinger Emtwo', type: 'dude' }]);
+                    expect(this.message.flatten()).toEqual(['Player 1 plays ', { argType: 'card', code: '12345', title: 'Funslinger Emtwo', type: 'dude', uuid: this.cardUuid }]);
                 });
             });
 

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -6,8 +6,8 @@ describe('BaseCard', function () {
         this.testCard = { code: '111', title: 'test 1', gang_code: 'neutral' };
         this.game = jasmine.createSpyObj('game', ['isCardVisible', 'raiseEvent']);
         this.owner = jasmine.createSpyObj('owner', ['getCardSelectionState', 'isSpectator']);
-        this.game.effectEngine = jasmine.createSpyObj('effectEngine', ['getAppliedEffectsOnCard']);
-        this.game.effectEngine.getAppliedEffectsOnCard.and.returnValue([]);
+        this.game.effectEngine = jasmine.createSpyObj('effectEngine', ['getAppliedEffectsOnTarget']);
+        this.game.effectEngine.getAppliedEffectsOnTarget.and.returnValue([]);
         this.owner.getCardSelectionState.and.returnValue({});
         this.owner.game = this.game;
         this.card = new BaseCard(this.owner, this.testCard);

--- a/test/server/card/drawcard.attachments.spec.js
+++ b/test/server/card/drawcard.attachments.spec.js
@@ -10,8 +10,8 @@ describe('DrawCard', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['isCardVisible']);
         this.gameSpy.isCardVisible.and.returnValue(true);
-        this.gameSpy.effectEngine = jasmine.createSpyObj('effectEngine', ['getAppliedEffectsOnCard']);
-        this.gameSpy.effectEngine.getAppliedEffectsOnCard.and.returnValue([]);
+        this.gameSpy.effectEngine = jasmine.createSpyObj('effectEngine', ['getAppliedEffectsOnTarget']);
+        this.gameSpy.effectEngine.getAppliedEffectsOnTarget.and.returnValue([]);
         this.testCard = { code: '111', title: 'test 1', gang_code: 'neutral' };
         this.card = new DrawCard({}, this.testCard);
         this.card.game = this.gameSpy;

--- a/test/server/card/drawcard.getsummary.spec.js
+++ b/test/server/card/drawcard.getsummary.spec.js
@@ -10,8 +10,8 @@ describe('DrawCard', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['isCardVisible']);
         this.gameSpy.isCardVisible.and.returnValue(true);
-        this.gameSpy.effectEngine = jasmine.createSpyObj('effectEngine', ['getAppliedEffectsOnCard']);
-        this.gameSpy.effectEngine.getAppliedEffectsOnCard.and.returnValue([]);
+        this.gameSpy.effectEngine = jasmine.createSpyObj('effectEngine', ['getAppliedEffectsOnTarget']);
+        this.gameSpy.effectEngine.getAppliedEffectsOnTarget.and.returnValue([]);
         this.testCard = { code: '111', title: 'test 1', gang_code: 'neutral' };
         this.card = new DrawCard({}, this.testCard);
         this.card.game = this.gameSpy;

--- a/test/server/cards/cancreatecards.spec.js
+++ b/test/server/cards/cancreatecards.spec.js
@@ -6,6 +6,7 @@ describe('All Cards', function() {
         this.playerSpy = jasmine.createSpyObj('player', ['registerAbilityMax']);
         this.playerSpy.game = this.gameSpy;
         this.gameSpy.getPlayers.and.returnValue([]);
+        this.gameSpy.townsquare = { title: 'Town Square '};
         this.hasAncestor = (cardClass, ancestorClassName) => {
             let prot = Object.getPrototypeOf(cardClass);
             while(prot && prot.name !== cardClass.name && prot.name !== ancestorClassName) {


### PR DESCRIPTION
To see effects, you just open an effect panel and hover over card, player area or shootout panel.
The effect panel can be opened by clicking either directly on Effects panel
![image](https://user-images.githubusercontent.com/10244559/203512471-13a9a199-dd02-4324-92a9-e68636ff041e.png)
or link in player area
![image](https://user-images.githubusercontent.com/10244559/203512565-cba4feb7-0835-4a6f-b6ff-f0d51e17ff1a.png)
or link in shootout panel.
Both these links should also contain number of effects in the parentheses. 

When hovered over card with effects, you should see its effects in the window/panel:
![image](https://user-images.githubusercontent.com/10244559/203513122-36470c2b-6bb7-4a17-9210-23bf8cd81538.png)
Positive stat modifiers are with the dark green background, negative with dark red. 

There is new visual token (flash in top right corner) on cards to indicate there are some effects applied to the card. Those are effects other than modifiers you can see on other tokens on the card (e.g. bullet modifiers, inf modifiers etc). So for example if there is only an effect giving dude +2 bullets (such as `War Paint`), there will be no flash icon since you can see the bullets have been changed due to the bullet token. However, if you use on the same dude `Hiding in the Shadows`, the flash should appear.
![image](https://user-images.githubusercontent.com/10244559/203513813-60c05968-fddb-476c-b7a8-c81525fef215.png)

