### PR TITLE
Changes to import scripts after updating PT instance with MM

### DIFF
--- a/server/scripts/fetchdata/DtDbImageSource.js
+++ b/server/scripts/fetchdata/DtDbImageSource.js
@@ -4,18 +4,27 @@ const jimp = require('jimp');
 const request = require('request');
 
 class DtDbImageSource {
-    constructor() {
-        this.packs = this.loadPacks();
+    constructor(options) {
+        this.onlyPack = options['only-pack'];
+        this.exceptPack = options['except-pack'];
+        this.packs = this.loadPacks(this.onlyPack, this.exceptPack);
     }
 
-    loadPacks() {
+    loadPacks(onlyPack, exceptPack) {
         let files = fs.readdirSync('townsquare-json-data/packs');
+
+        if (onlyPack) 
+            files = files.find(file => file === onlyPack + '.json');
+
+        if (exceptPack)
+            files = files.filter(file => file !== exceptPack + '.json');
+
         return files.map(file => JSON.parse(fs.readFileSync('townsquare-json-data/packs/' + file)));
     }
 
     fetchImage(card, imagePath) {
         if(!card.imagesrc) {
-            console.log(`Could not fetch image for ${card.title} as there is no image srouce "imagesrc"`);
+            console.log(`Could not fetch image for ${card.title} as there is no image source "imagesrc"`);
             return;
         }
 

--- a/server/scripts/fetchdata/PTDbImageSource.js
+++ b/server/scripts/fetchdata/PTDbImageSource.js
@@ -1,0 +1,56 @@
+/*eslint no-console:0 */
+const fs = require('fs');
+const jimp = require('jimp');
+const request = require('request');
+
+class PTDbImageSource {
+  constructor(options) {
+    this.onlyPack = options['only-pack'];
+    this.exceptPack = options['except-pack'];
+    this.username = options.username;
+    this.password = options.password;
+
+    this.packs = this.loadPacks(this.onlyPack, this.exceptPack);
+  }
+
+  loadPacks(onlyPack, exceptPack) {
+    let files = fs.readdirSync('townsquare-json-data/packs');
+    
+    if (onlyPack) {
+      return files.find(file => file === onlyPack + '.json');
+    }
+
+    if (exceptPack) {
+      files = files.filter(file => file !== exceptPack + '.json');      
+      return files.map(file => JSON.parse(fs.readFileSync('townsquare-json-data/packs/' + file)));
+    }
+
+    return null;
+  }
+
+  fetchImage(card, imagePath) {
+    if(!card.imagesrc) {
+        console.log(`Could not fetch image for ${card.title} as there is no image source "imagesrc"`);
+        return;
+    }
+
+    let imagesrc = card.imagesrc;
+    let url = `http://${this.username}:${this.password}@192.241.162.104/${imagesrc}`;
+
+    request({ url: url, encoding: null }, function(err, response, body) {
+        if(err || response.statusCode !== 200) {
+            console.log(`Unable to fetch image for ${card.code} from ${url}`);
+            return;
+        }
+
+        console.log('Downloading image for ' + card.code);
+        jimp.read(body).then(lenna => {
+            lenna.write(imagePath);
+        }).catch(err => {
+            console.log(`Error converting image for ${card.code}: ${err}`);
+        });
+    });
+  }
+}
+
+module.exports = PTDbImageSource;

--- a/server/scripts/updateUser.js
+++ b/server/scripts/updateUser.js
@@ -1,0 +1,71 @@
+/*eslint no-console:0 */
+const monk = require('monk');
+const bcrypt = require('bcrypt');
+const UserService = require('../services/UserService.js');
+
+if(process.argv.length < 4) {
+    console.log('Missing some parameters!');
+    return;
+}
+
+const actionType = process.argv[2];
+const userName = process.argv[3];
+const db = monk('mongodb://127.0.0.1:27017/townsquare');
+const userService = new UserService(db);
+
+async function newUser() {
+    let passwordHash = await hashPassword('4thelulZ{?)', 10);
+    let newUser = {
+        password: passwordHash,
+        registered: new Date(),
+        username: userName,
+        email: 'dummy@email.com',
+        enableGravatar: '',
+        verified: true,
+        registerIp: '127.0.0.1'
+    };
+    await userService.addUser(newUser);
+    db.close();
+}
+
+async function getUser() {
+    let user = await userService.getUserByUsername(userName);
+    user.userData.permissions = {
+        isAdmin:'true',
+        canEditNews:'true',
+        canManageUsers:'true',
+        canManagePermissions:'true',
+        canManageGames:true,
+        canManageMotd:true,
+        canManageNodes:true,
+        canManageBanlist:true,
+        canModerateChat:true,
+        canManageEvents:true,
+        isSupporter:true,
+        isContributor:true
+    };
+    return user.userData;
+}
+
+async function updateUserToAdmin() {
+    let user = await getUser();
+    await userService.update(user);
+    db.close();
+}
+function hashPassword(password, rounds) {
+    return new Promise((resolve, reject) => {
+        bcrypt.hash(password, rounds, function(err, hash) {
+            if(err) {
+                return reject(err);
+            }
+            return resolve(hash);
+        });
+    });
+}
+
+if(actionType === '-u') {
+    updateUserToAdmin();
+}
+if(actionType === '-a') {
+    newUser();
+}

--- a/server/services/CardService.js
+++ b/server/services/CardService.js
@@ -16,9 +16,17 @@ class CardService {
             .then(() => this.cards.insert(cards));
     }
 
-    replacePacks(cards) {
+    addCards(cards) {
+        return this.cards.insert(cards);
+    }
+
+    replacePacks(packs) {
         return this.packs.remove({})
-            .then(() => this.packs.insert(cards));
+            .then(() => this.packs.insert(packs));
+    }
+
+    addPacks(packs) {
+        return this.packs.insert(packs);
     }
 
     getAllCards() {


### PR DESCRIPTION
These changes are from the effort to update the playtest DTO instance to include the new MM set.

### fetchdata.js
1. Added additional command line parameters to make things easier to manage imports
  - only-images (default: true): Only download images, no card imports into mongo
  - replace-cards (default: true): Empty the cards table before adding cards from the pack
  - replace-packs (default: true): Empty the packs table before adding packs
  - only-pack (default: null): Only read the indicated pack for update purposes
  - except-pack (default: null): Read all packs except the indicated pack
  - username (default: null): username for the ptdb database
  - password (default: null): password for the ptdb database
2. References new PTDbImageSource class for handling PTDB image source
3. We now inject CardService into CardImport to adhere to Dependency Inversion Principle of SOLID
4. We now pass the entire command-line Options object into CardImport, as the number of individual parameters was getting unwieldy

### CardImport.js
1. Entire command-line Options object now passed into constructor, removing individual options
2. More class fields pulled from Options in constructor
3. Handles new command-line flags

### DTDbImageSource.js
1. Handles new command-line flags
2. PTDB logic removed to adhere to Single-Responsibility Principle of SOLID

### PTDbImageSource.js
New class that handles importing images from PTDB

### updateUser.js
Added new script that was found on PT DTO, but wasn't in repo.

### CardService.js
Added new addCards and addPacks methods
